### PR TITLE
chore: limit renovate to once a day

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,22 @@
 {
-  "extends": ["config:recommended"],
+  "extends": [
+    "config:recommended"
+  ],
   "prConcurrentLimit": 1,
   "prHourlyLimit": 10,
   "minimumReleaseAge": "1 day",
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"
     }
-  ]
+  ],
+  "schedule": [
+    "once a day"
+  ],
+  "timezone": "Europe/London"
 }


### PR DESCRIPTION
## Summary
- Change Renovate schedule from `every weekday` (or default) to `once a day`
- Add `timezone: Europe/London` where missing

This reduces PR noise by ensuring Renovate only raises PRs once per day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)