### PR TITLE
fix: use valid renovate schedule syntax

### DIFF
--- a/context/GameScoreContext.spec.tsx
+++ b/context/GameScoreContext.spec.tsx
@@ -19,7 +19,7 @@ describe('GameScoreProvider', () => {
 
     expect(screen.getByText('11')).toBeInTheDocument();
   });
-  it('should process setGameScore correctly for team 1', () => {
+  it('should process setGameScore correctly for team  1', () => {
     const MockChildComponent = () => {
       const { gameScore, setGameScore } = useGameScore();
 

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
     }
   ],
   "schedule": [
-    "once a day"
+    "after 4am and before 5am"
   ],
   "timezone": "Europe/London"
 }


### PR DESCRIPTION
## Summary
- Fix invalid `"once a day"` schedule which broke Renovate
- Replace with `"after 4am and before 5am"` — a valid later.js expression that runs Renovate in a 1-hour window daily

🤖 Generated with [Claude Code](https://claude.com/claude-code)