### PR TITLE
fix: remove unnecessary `as any` from FooterContainer styled component

### DIFF
--- a/components/footer/footer.tsx
+++ b/components/footer/footer.tsx
@@ -20,7 +20,7 @@ const FooterContainer = styled.footer`
   p {
     margin: 0;
   }
-` as any;
+`;
 
 export default function Footer() {
   return (


### PR DESCRIPTION
## Summary

- Removes the `as any` type assertion from the `FooterContainer` styled component in `components/footer/footer.tsx`
- `styled.footer` works correctly with Emotion's TypeScript types without the assertion, so the cast was unnecessary and was suppressing type safety

## Test plan

- [x] `yarn tsc --noEmit` passes with no type errors
- [x] `yarn jest components/footer` passes (3 tests, 100% coverage on footer.tsx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)