### PR TITLE
Add contact email to footer

### DIFF
--- a/components/footer/footer.tsx
+++ b/components/footer/footer.tsx
@@ -12,6 +12,9 @@ export default function Footer() {
         <FooterRight>
           <FooterBrand>20Twenty &amp; Score &middot; MMXXVI</FooterBrand>
           <FooterAttribution>
+            <a href="mailto:hello@20twentyscore.co.uk">hello@20twentyscore.co.uk</a>
+          </FooterAttribution>
+          <FooterAttribution>
             Icons by{' '}
             <a href="https://www.flaticon.com/authors/smashicons" title="Smashicons">
               Smashicons


### PR DESCRIPTION
## Summary
- Adds `hello@20twentyscore.co.uk` as a `mailto:` link in the site footer
- Sits between the brand name and the icon attribution, using the existing `FooterAttribution` style

## Test plan
- [ ] Visit the app and confirm the email appears in the footer
- [ ] Click the link and confirm it opens a mail client addressed to `hello@20twentyscore.co.uk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)