### PR TITLE
Remove unused SCORECARD label from summary page

### DIFF
--- a/pages/summary.tsx
+++ b/pages/summary.tsx
@@ -97,7 +97,6 @@ const SummaryPage: React.FC = () => {
             <PageTitle>Match summary</PageTitle>
             <TitleRule />
           </PageTitleGroup>
-          <ScorecardLabel>SCORECARD</ScorecardLabel>
         </PageHeader>
 
         <ScorePanel>
@@ -231,14 +230,6 @@ const TitleRule = styled.hr`
   border: none;
   border-top: 1px solid #1a1a1a;
   margin: 0;
-`;
-
-const ScorecardLabel = styled.span`
-  font-family: 'Inter', sans-serif;
-  font-size: 0.7rem;
-  letter-spacing: 0.12em;
-  color: #767676;
-  white-space: nowrap;
 `;
 
 const ScorePanel = styled.div`


### PR DESCRIPTION
## Summary
- Removes the `SCORECARD` text label from the summary page header
- Deletes the unused `ScorecardLabel` styled component

Closes #338

## Test plan
- [ ] Visit the summary page and confirm the "SCORECARD" label no longer appears in the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)