### PR TITLE
Match Moments — milestone celebration toasts

### DIFF
--- a/components/milestone/MilestoneToast.tsx
+++ b/components/milestone/MilestoneToast.tsx
@@ -1,0 +1,46 @@
+import { keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
+import type React from 'react';
+import { MILESTONE_DURATION_MS } from '../../utils/useMilestone';
+
+type Props = {
+  message: string;
+  accent: string;
+};
+
+export const MilestoneToast: React.FC<Props> = ({ message, accent }) => (
+  <Toast accent={accent}>
+    <Message>{message}</Message>
+  </Toast>
+);
+
+const toastAnim = keyframes`
+  0%   { transform: translateY(-100%); opacity: 0; }
+  10%  { transform: translateY(0);     opacity: 1; }
+  80%  { transform: translateY(0);     opacity: 1; }
+  100% { transform: translateY(-20px); opacity: 0; }
+`;
+
+const Toast = styled.div<{ accent: string }>`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  background-color: #1a1a1a;
+  border-bottom: 3px solid ${({ accent }) => accent};
+  padding: 1rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: ${toastAnim} ${MILESTONE_DURATION_MS}ms ease forwards;
+`;
+
+const Message = styled.p`
+  font-family: 'Bodoni Moda', serif;
+  font-style: italic;
+  font-size: 1.5rem;
+  color: #fff;
+  margin: 0;
+  text-align: center;
+`;

--- a/pages/match.tsx
+++ b/pages/match.tsx
@@ -2,11 +2,13 @@ import styled from "@emotion/styled";
 import Link from "next/link";
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
+import { MilestoneToast } from "../components/milestone/MilestoneToast";
 import Layout from "../components/layout/layout";
 import Scoring from "../components/scoring/scoring";
 import { useGameScore } from "../context/GameScoreContext";
 import { useMostRecentAction } from "../context/MostRecentActionContext";
 import { useOvers } from "../context/OversContext";
+import { useMilestone } from "../utils/useMilestone";
 
 const TOTAL_OVERS = 20;
 const BALLS_PER_OVER = 6;
@@ -21,6 +23,7 @@ const MatchPage: React.FC = () => {
   const { currentOver, currentBallInThisOver, currentExtrasInThisOver } =
     useOvers();
   const { mostRecentAction } = useMostRecentAction();
+  const milestone = useMilestone(mostRecentAction, gameScore, currentOver);
 
   const formatOvers = (overs: number, isBatting: boolean) => {
     const balls = isBatting
@@ -147,6 +150,7 @@ const MatchPage: React.FC = () => {
 
   return (
     <Layout>
+      {milestone && <MilestoneToast message={milestone.message} accent={milestone.accent} />}
       <Main>
         <PageHeader>
           <PageTitleGroup>

--- a/utils/useMilestone.ts
+++ b/utils/useMilestone.ts
@@ -1,0 +1,91 @@
+import { useEffect, useRef, useState } from 'react';
+import type { GameScore } from '../context/GameContext';
+
+export type MilestoneEvent = {
+  message: string;
+  accent: string;
+};
+
+export const MILESTONE_DURATION_MS = 2500;
+
+export function useMilestone(
+  mostRecentAction: { runs: number; action: string | null },
+  gameScore: GameScore,
+  currentOver: number
+): MilestoneEvent | null {
+  const [event, setEvent] = useState<MilestoneEvent | null>(null);
+  const prevStrikerRunsRef = useRef<number>(0);
+  const prevOverRef = useRef<number | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const actionInitRef = useRef(false);
+
+  const currentBattingTeam = gameScore.find((t) => t.currentBattingTeam);
+  const striker = currentBattingTeam?.players.find((p) => p.currentStriker);
+
+  const triggerMilestone = (milestone: MilestoneEvent) => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setEvent(milestone);
+    timerRef.current = setTimeout(() => setEvent(null), MILESTONE_DURATION_MS);
+  };
+
+  // Ball-by-ball milestone detection
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally run only on mostRecentAction change
+  useEffect(() => {
+    const currRuns = striker?.runs ?? 0;
+
+    if (!actionInitRef.current) {
+      actionInitRef.current = true;
+      prevStrikerRunsRef.current = currRuns;
+      return;
+    }
+
+    const { runs, action } = mostRecentAction;
+    const prevRuns = prevStrikerRunsRef.current;
+    const balls = striker?.allActions.filter((a) => a !== 'Wide').length ?? 0;
+
+    if (action === 'Wicket') {
+      triggerMilestone({ message: 'WICKET!', accent: '#b83320' });
+    } else if (prevRuns < 100 && currRuns >= 100) {
+      triggerMilestone({
+        message: `CENTURY! · ${striker?.name ?? 'Batter'} · ${currRuns} off ${balls}`,
+        accent: '#c9a84c',
+      });
+    } else if (prevRuns < 50 && currRuns >= 50) {
+      triggerMilestone({
+        message: `FIFTY! · ${striker?.name ?? 'Batter'} · ${currRuns} off ${balls}`,
+        accent: '#c9a84c',
+      });
+    } else if (runs === 6) {
+      triggerMilestone({
+        message: `SIX! · ${striker?.name ?? 'Batter'} · ${currRuns} off ${balls}`,
+        accent: '#c9a84c',
+      });
+    } else if (runs === 4) {
+      triggerMilestone({
+        message: `FOUR! · ${striker?.name ?? 'Batter'}`,
+        accent: '#b83320',
+      });
+    }
+
+    prevStrikerRunsRef.current = currRuns;
+  }, [mostRecentAction]);
+
+  // End of over detection
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally run only on currentOver change
+  useEffect(() => {
+    if (prevOverRef.current === null) {
+      prevOverRef.current = currentOver;
+      return;
+    }
+    if (currentOver === prevOverRef.current) return;
+    const completedOver = prevOverRef.current;
+    prevOverRef.current = currentOver;
+    triggerMilestone({ message: `End of over ${completedOver}`, accent: '#2d7a4f' });
+  }, [currentOver]);
+
+  useEffect(() => () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+  }, []);
+
+  return event;
+}


### PR DESCRIPTION
## Summary

- Adds `useMilestone` hook (`utils/useMilestone.ts`) that detects match events — six, four, wicket, batter reaching 50/100, and end of over — from existing context hooks with no new context or reducer changes
- Adds `MilestoneToast` component (`components/milestone/MilestoneToast.tsx`): a fixed full-width banner that slides in from the top, holds, then fades out over 2.5s via a single CSS keyframe animation
- Wires both into `pages/match.tsx` — one hook call and one conditional render

Closes #336

## Test plan

- [ ] Score a 4 — FOUR! banner appears with batter name and fades after 2.5s
- [ ] Score a 6 — SIX! banner appears with batter name, current score off balls faced
- [ ] Take a wicket — WICKET! banner appears
- [ ] Score a batter to exactly 50 — FIFTY! banner with name and score
- [ ] Score a batter to exactly 100 — CENTURY! banner
- [ ] Complete an over — End of over N banner
- [ ] Milestones don't fire on page load / navigation to an in-progress match
- [ ] All 76 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)