### PR TITLE
Add copy scorecard button to summary page

### DIFF
--- a/pages/summary.tsx
+++ b/pages/summary.tsx
@@ -7,6 +7,7 @@ import Layout from '../components/layout/layout';
 import { useGameScore } from '../context/GameScoreContext';
 import type { Team } from '../context/GameContext';
 import { generateSaveTitle } from '../lib/gameSaveTitle';
+import { formatShareText } from '../utils/formatShareText';
 
 const TEAM_COLORS = ['#b83320', '#2d7a4f'] as const;
 
@@ -41,6 +42,13 @@ const SummaryPage: React.FC = () => {
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const copyScorecard = async () => {
+    await navigator.clipboard.writeText(formatShareText(gameScore as [Team, Team]));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
 
   const battingTeam = gameScore.find((t) => t.currentBattingTeam) ?? gameScore[0];
   const bowlingTeam = gameScore.find((t) => t.currentBowlingTeam) ?? gameScore[1];
@@ -160,6 +168,12 @@ const SummaryPage: React.FC = () => {
               </ResultBody>
             </>
           )}
+
+          <CopySection>
+            <CopyButton onClick={copyScorecard} data-analytics="copy-scorecard">
+              {copied ? 'Copied ✓' : 'Copy scorecard'}
+            </CopyButton>
+          </CopySection>
 
           {session && (
             <CloudSaveSection>
@@ -436,6 +450,31 @@ const SaveMessage = styled.p<{ error?: boolean }>`
   color: ${({ error }) => (error ? '#b83320' : '#2d7a4f')};
   font-weight: 700;
   margin: 0;
+`;
+
+const CopySection = styled.div`
+  margin-top: 1.25rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid #e0e0e0;
+`;
+
+const CopyButton = styled.button`
+  font-family: 'Inter', sans-serif;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.5rem 1.25rem;
+  border-radius: 999px;
+  border: 2px solid #333;
+  background-color: #fff;
+  color: #333;
+  cursor: pointer;
+  transition: background-color 0.2s, color 0.2s;
+
+  &:hover {
+    background-color: #f0f0f0;
+  }
 `;
 
 const ResultBody = styled.p`

--- a/utils/formatShareText.spec.ts
+++ b/utils/formatShareText.spec.ts
@@ -1,0 +1,49 @@
+import { formatShareText } from './formatShareText';
+import type { Team } from '../context/GameContext';
+
+const baseTeam = (overrides: Partial<Team>): Team => ({
+  players: [],
+  name: 'Team 1',
+  index: 0,
+  totalRuns: 0,
+  totalWicketsConceded: 0,
+  totalWicketsTaken: 0,
+  overs: 0,
+  currentBattingTeam: false,
+  currentBowlingTeam: false,
+  finishedBatting: false,
+  ...overrides,
+});
+
+describe('formatShareText', () => {
+  it('includes header and both team scores', () => {
+    const t0 = baseTeam({ name: 'Team 1', totalRuns: 134, totalWicketsConceded: 6, overs: 20 });
+    const t1 = baseTeam({ name: 'Team 2', index: 1, totalRuns: 98, totalWicketsConceded: 8, overs: 18.3 });
+    const text = formatShareText([t0, t1]);
+    expect(text).toContain('20TwentyScore · T20');
+    expect(text).toContain('134/6');
+    expect(text).toContain('98/8');
+    expect(text).toContain('RR 6.70');
+  });
+
+  it('includes result when both teams have finished batting', () => {
+    const t0 = baseTeam({ name: 'Team 1', totalRuns: 134, totalWicketsConceded: 6, overs: 20, finishedBatting: true });
+    const t1 = baseTeam({ name: 'Team 2', index: 1, totalRuns: 98, totalWicketsConceded: 8, overs: 18.3, finishedBatting: true });
+    const text = formatShareText([t0, t1]);
+    expect(text).toContain('Result: Team 1 win by 36 runs');
+  });
+
+  it('omits result when match is in progress', () => {
+    const t0 = baseTeam({ name: 'Team 1', totalRuns: 50, overs: 10 });
+    const t1 = baseTeam({ name: 'Team 2', index: 1 });
+    const text = formatShareText([t0, t1]);
+    expect(text).not.toContain('Result:');
+  });
+
+  it('shows drawn result when scores are equal', () => {
+    const t0 = baseTeam({ name: 'Team 1', totalRuns: 100, overs: 20, finishedBatting: true });
+    const t1 = baseTeam({ name: 'Team 2', index: 1, totalRuns: 100, overs: 20, finishedBatting: true });
+    const text = formatShareText([t0, t1]);
+    expect(text).toContain('Result: Match drawn');
+  });
+});

--- a/utils/formatShareText.ts
+++ b/utils/formatShareText.ts
@@ -1,0 +1,37 @@
+import type { Team } from '../context/GameContext';
+
+function calcRunRate(runs: number, overs: number): string {
+  if (overs === 0) return '0.00';
+  return (runs / overs).toFixed(2);
+}
+
+function formatOvers(overs: number): string {
+  return overs.toFixed(1);
+}
+
+function determineResult(teams: [Team, Team]): string | null {
+  const [t0, t1] = teams;
+  if (!t0.finishedBatting || !t1.finishedBatting) return null;
+  if (t0.totalRuns > t1.totalRuns) return `${t0.name} win by ${t0.totalRuns - t1.totalRuns} runs`;
+  if (t1.totalRuns > t0.totalRuns) return `${t1.name} win by ${t1.totalRuns - t0.totalRuns} runs`;
+  return 'Match drawn';
+}
+
+export function formatShareText(teams: [Team, Team]): string {
+  const lines: string[] = ['20TwentyScore · T20', ''];
+
+  for (const team of teams) {
+    const score = `${team.totalRuns}/${team.totalWicketsConceded}`;
+    const overs = `(${formatOvers(team.overs)} ov)`;
+    const rr = `RR ${calcRunRate(team.totalRuns, team.overs)}`;
+    lines.push(`${team.name.padEnd(12)} ${score.padEnd(6)} ${overs.padEnd(12)} ${rr}`);
+  }
+
+  const result = determineResult(teams);
+  if (result) {
+    lines.push('');
+    lines.push(`Result: ${result}`);
+  }
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary

- Adds `utils/formatShareText.ts` — pure function that serialises match state into a shareable plain-text scorecard
- Adds a **Copy scorecard** button to `pages/summary.tsx` that writes the formatted text to the clipboard and briefly shows "Copied ✓" for 2 s
- Button is always visible (mid-innings and at match end), labelled with `data-analytics="copy-scorecard"`
- Adds 4 unit tests covering both teams' scores, win/draw result, and in-progress (no result) cases

Closes #334

## Test plan

- [ ] Visit `/summary` with an active or completed match
- [ ] Click "Copy scorecard" and paste into a chat — confirm the text matches the expected format
- [ ] Confirm the button label flips to "Copied ✓" for ~2 s then resets
- [ ] Unit tests: `yarn jest utils/formatShareText.spec.ts` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)