### PR TITLE
chore(a11y/seo): unique page titles, Twitter cards, canonical URLs, and accessibility fixes

### DIFF
--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -7,18 +7,20 @@ import Meta from '../meta/meta';
 
 type Props = {
   children: ReactNode;
+  title?: string;
+  description?: string;
 };
 
-const Layout: React.FC<Props> = (props) => {
+const Layout: React.FC<Props> = ({ children, title, description }) => {
   return (
     <SiteContainer>
-      <Meta />
+      <Meta title={title} description={description} />
       <Header />
       <BetaBanner role="region" aria-label="Beta notice">
         This site is new and may have rough edges. For suggestions or issues, email{' '}
         <a href="mailto:hello@20twentyscore.co.uk">hello@20twentyscore.co.uk</a>
       </BetaBanner>
-      <Content>{props.children}</Content>
+      <Content>{children}</Content>
       <Footer />
     </SiteContainer>
   );

--- a/components/meta/meta.spec.tsx
+++ b/components/meta/meta.spec.tsx
@@ -22,7 +22,7 @@ jest.mock('next/head', () => {
 useRouterMock.mockReturnValue({
   basePath: '',
   isLocaleDomain: false,
-  asPath: '',
+  asPath: '/',
   push: async () => true,
   replace: async () => true,
   reload: () => null,
@@ -48,8 +48,8 @@ describe('Meta', () => {
     const ogUrlMetaDescription = document.querySelector('meta[property="og:description"]');
     expect(ogUrlMetaDescription).toBeTruthy();
     expect(ogUrlMetaDescription?.getAttribute('content')).toBe(
-      '20 Twenty Scorecard - keep scores of your 20 Twenty games'
+      'Track your T20 cricket match ball by ball — runs, wickets, extras, and live run rates.'
     );
-    expect(document.title).toBe('20Twenty Scorecard');
+    expect(document.title).toBe('20Twenty Score');
   });
 });

--- a/components/meta/meta.tsx
+++ b/components/meta/meta.tsx
@@ -1,11 +1,23 @@
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 
-export default function Meta() {
+type Props = {
+  title?: string;
+  description?: string;
+};
+
+const SITE_NAME = '20Twenty Score';
+const SITE_URL = 'https://20-twenty-score.vercel.app';
+const DEFAULT_DESCRIPTION =
+  'Track your T20 cricket match ball by ball — runs, wickets, extras, and live run rates.';
+const OG_IMAGE = '/images/temp-seo-image.jpg';
+
+export default function Meta({ title, description }: Props) {
   const router = useRouter();
-  const currentUrl = router.asPath ?? '';
-  const siteAddress = 'https://20-twenty-score.vercel.app/';
-  const defaultImageUrl = '/images/temp-seo-image.jpg';
+  const currentUrl = router.asPath ?? '/';
+  const pageTitle = title ? `${title} | ${SITE_NAME}` : SITE_NAME;
+  const pageDescription = description ?? DEFAULT_DESCRIPTION;
+  const canonicalUrl = `${SITE_URL}${currentUrl}`;
   return (
     <Head>
       <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
@@ -18,22 +30,21 @@ export default function Meta() {
       <meta name="msapplication-config" content="/favicon/browserconfig.xml" />
       <meta name="theme-color" content="#000" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <title>{pageTitle}</title>
+      <meta name="description" content={pageDescription} />
+      <link rel="canonical" href={canonicalUrl} />
       <meta property="og:locale" content="en_GB" />
-      <meta property="og:type" content="article" />
-      <meta property="og:title" content={'20 Twenty Scorecard'} />
-      <meta
-        property="og:description"
-        content={'20 Twenty Scorecard - keep scores of your 20 Twenty games'}
-      />
-      <meta property="og:site_name" content={'20 Twenty Scorecard'} />
-      <meta property="og:url" content={`${siteAddress}${currentUrl}`} />
-      <meta property="og:image" content={defaultImageUrl} />
+      <meta property="og:type" content="website" />
+      <meta property="og:title" content={pageTitle} />
+      <meta property="og:description" content={pageDescription} />
+      <meta property="og:site_name" content={SITE_NAME} />
+      <meta property="og:url" content={canonicalUrl} />
+      <meta property="og:image" content={OG_IMAGE} />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={pageTitle} />
+      <meta name="twitter:description" content={pageDescription} />
+      <meta name="twitter:image" content={OG_IMAGE} />
       <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
-      <meta
-        name="description"
-        content={'20 Twenty Scorecard - keep scores of your 20 Twenty games'}
-      />
-      <title>20Twenty Scorecard</title>
     </Head>
   );
 }

--- a/components/milestone/MilestoneToast.tsx
+++ b/components/milestone/MilestoneToast.tsx
@@ -9,7 +9,7 @@ type Props = {
 };
 
 export const MilestoneToast: React.FC<Props> = ({ message, accent }) => (
-  <Toast accent={accent}>
+  <Toast accent={accent} role="status" aria-live="polite" aria-atomic="true">
     <Message>{message}</Message>
   </Toast>
 );

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -30,7 +30,10 @@ export default function AccountPage() {
 
   if (isLoading) {
     return (
-      <Layout>
+      <Layout
+        title="Account"
+        description="Manage your 20Twenty Score account and subscription."
+      >
         <PageWrapper>
           <LoadingText>Loading…</LoadingText>
         </PageWrapper>
@@ -39,7 +42,10 @@ export default function AccountPage() {
   }
 
   return (
-    <Layout>
+    <Layout
+      title="Account"
+      description="Manage your 20Twenty Score account and subscription."
+    >
       <PageWrapper>
         <PageTitle>Account</PageTitle>
 

--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -1,5 +1,6 @@
 import { signIn } from 'next-auth/react';
 import styled from '@emotion/styled';
+import Head from 'next/head';
 import { PrimaryButton } from '../../components/core/buttons';
 
 const Container = styled.div`
@@ -36,6 +37,10 @@ const ButtonGroup = styled.div`
 export default function SignIn() {
   return (
     <Container>
+      <Head>
+        <title>Sign In | 20Twenty Score</title>
+        <meta name="description" content="Sign in to 20Twenty Score to save your games and manage your cricket seasons." />
+      </Head>
       <Title>20Twenty Score</Title>
       <Subtitle>Sign in to save your games and seasons</Subtitle>
       <ButtonGroup>

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -131,7 +131,10 @@ export default function DashboardPage() {
 
   if (!session) {
     return (
-      <Layout>
+      <Layout
+        title="Dashboard"
+        description="View and manage your cloud saves and cricket seasons."
+      >
         <PageWrapper>
           <p>
             Please <Link href="/auth/signin">sign in</Link> to view your
@@ -143,7 +146,10 @@ export default function DashboardPage() {
   }
 
   return (
-    <Layout>
+    <Layout
+      title="Dashboard"
+      description="View and manage your cloud saves and cricket seasons."
+    >
       <PageWrapper>
         {checkoutSuccess && (
           <CheckoutBanner>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -71,7 +71,9 @@ const Index: React.FC = () => {
   };
 
   return (
-    <Layout>
+    <Layout
+      description="Track your T20 cricket match ball by ball. Start a new game or resume a saved match."
+    >
       <Main>
         <Welcome>Welcome to 20Twenty Score</Welcome>
         <HeroSection>

--- a/pages/match.tsx
+++ b/pages/match.tsx
@@ -155,7 +155,10 @@ const MatchPage: React.FC = () => {
 
   if (!hasGame) {
     return (
-      <Layout>
+      <Layout
+        title="Today's Match"
+        description="Live scoring for your T20 cricket match. Record runs, wickets, and extras ball by ball."
+      >
         <Main>
           <PageHeader>
             <PageTitleGroup>
@@ -174,7 +177,10 @@ const MatchPage: React.FC = () => {
   }
 
   return (
-    <Layout>
+    <Layout
+      title="Today's Match"
+      description="Live scoring for your T20 cricket match. Record runs, wickets, and extras ball by ball."
+    >
       {milestone && <MilestoneToast message={milestone.message} accent={milestone.accent} />}
       <Main>
         <PageHeader>
@@ -521,15 +527,10 @@ const MatchPage: React.FC = () => {
                     return (
                       <BowlerListItem
                         key={player.name}
+                        type="button"
                         disabled={isJustBowled}
-                        onClick={
-                          !isJustBowled
-                            ? () =>
-                                settingBowler(
-                                  currentBowlingTeam.index,
-                                  player.index
-                                )
-                            : undefined
+                        onClick={() =>
+                          settingBowler(currentBowlingTeam.index, player.index)
                         }
                       >
                         <BowlerItemNumber disabled={isJustBowled}>
@@ -947,12 +948,18 @@ const BowlerList = styled.div`
   flex: 1;
 `;
 
-const BowlerListItem = styled.div<{ disabled?: boolean }>`
+const BowlerListItem = styled.button`
   display: flex;
   align-items: center;
   gap: 0.75rem;
   padding: 0.75rem 0.5rem;
+  background: none;
+  border: none;
   border-bottom: 1px solid #eee;
+  border-radius: 0;
+  width: 100%;
+  text-align: left;
+  font: inherit;
   cursor: ${({ disabled }) => (disabled ? "default" : "pointer")};
   opacity: ${({ disabled }) => (disabled ? 0.45 : 1)};
   transition: background-color 0.15s;
@@ -961,8 +968,8 @@ const BowlerListItem = styled.div<{ disabled?: boolean }>`
     border-bottom: none;
   }
 
-  &:hover {
-    background-color: ${({ disabled }) => (disabled ? "transparent" : "#f7f5f0")};
+  &:hover:not(:disabled) {
+    background-color: #f7f5f0;
     border-radius: 8px;
   }
 `;

--- a/pages/scoreboard.tsx
+++ b/pages/scoreboard.tsx
@@ -5,7 +5,10 @@ import Layout from "../components/layout/layout";
 
 const ScoreboardPage: React.FC = () => {
   return (
-    <Layout>
+    <Layout
+      title="Scoreboard"
+      description="Full scoreboard for the current T20 cricket match."
+    >
       <Main>
         <EmptyState>
           <p>Scoreboard coming soon. </p>

--- a/pages/seasons/[id].tsx
+++ b/pages/seasons/[id].tsx
@@ -50,7 +50,10 @@ export default function SeasonDetailPage() {
 
   if (!session) {
     return (
-      <Layout>
+      <Layout
+        title="Season"
+        description="View match saves for this cricket season."
+      >
         <PageWrapper>
           <p>
             Please <Link href="/auth/signin">sign in</Link> to view this season.
@@ -62,7 +65,10 @@ export default function SeasonDetailPage() {
 
   if (loading) {
     return (
-      <Layout>
+      <Layout
+        title="Season"
+        description="View match saves for this cricket season."
+      >
         <PageWrapper>
           <EmptyState>Loading season…</EmptyState>
         </PageWrapper>
@@ -72,7 +78,10 @@ export default function SeasonDetailPage() {
 
   if (notFound || !season) {
     return (
-      <Layout>
+      <Layout
+        title="Season not found"
+        description="This season could not be found."
+      >
         <PageWrapper>
           <EmptyState>Season not found.</EmptyState>
           <BackLink href="/seasons">← Back to seasons</BackLink>
@@ -82,7 +91,10 @@ export default function SeasonDetailPage() {
   }
 
   return (
-    <Layout>
+    <Layout
+      title={season.name}
+      description={`Season: ${season.name} — match saves on 20Twenty Score.`}
+    >
       <PageWrapper>
         <BackLink href="/seasons">← Back to seasons</BackLink>
         <PageTitle>{season.name}</PageTitle>

--- a/pages/seasons/index.tsx
+++ b/pages/seasons/index.tsx
@@ -63,7 +63,10 @@ export default function SeasonsPage() {
 
   if (!session) {
     return (
-      <Layout>
+      <Layout
+        title="Seasons"
+        description="Create and manage your T20 cricket seasons to group and track your matches."
+      >
         <PageWrapper>
           <p>
             Please <Link href="/auth/signin">sign in</Link> to view your seasons.
@@ -75,7 +78,10 @@ export default function SeasonsPage() {
 
   if (!accountLoading && tier === 'free') {
     return (
-      <Layout>
+      <Layout
+        title="Seasons"
+        description="Create and manage your T20 cricket seasons to group and track your matches."
+      >
         <PageWrapper>
           <PageTitle>Seasons</PageTitle>
           <UpgradeCTA />
@@ -85,7 +91,10 @@ export default function SeasonsPage() {
   }
 
   return (
-    <Layout>
+    <Layout
+      title="Seasons"
+      description="Create and manage your T20 cricket seasons to group and track your matches."
+    >
       <PageWrapper>
         <PageHeader>
           <PageTitle>Seasons</PageTitle>
@@ -98,7 +107,9 @@ export default function SeasonsPage() {
 
         {formOpen && (
           <Form onSubmit={createSeason}>
+            <label htmlFor="season-name" className="visually-hidden">Season name</label>
             <Input
+              id="season-name"
               type="text"
               placeholder="Season name"
               value={newName}

--- a/pages/summary.tsx
+++ b/pages/summary.tsx
@@ -98,7 +98,10 @@ const SummaryPage: React.FC = () => {
   };
 
   return (
-    <Layout>
+    <Layout
+      title="Match Summary"
+      description="Final scores, run rates, and batting and bowling figures from your T20 cricket match."
+    >
       <PageWrapper>
         <PageHeader>
           <PageTitleGroup>

--- a/pages/teams.tsx
+++ b/pages/teams.tsx
@@ -35,7 +35,10 @@ const TeamsPage: React.FC = () => {
   const battingTeamIndex = battingTeam?.index ?? 0;
 
   return (
-    <Layout>
+    <Layout
+      title="The Two XIs"
+      description="View squad lists and current player stats for both teams in the match."
+    >
       <PageWrapper>
         <PageHeader>
           <PageTitleGroup>


### PR DESCRIPTION
## Summary

- **Meta component**: accepts optional `title` and `description` props; adds Twitter card meta tags (`twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`); adds `<link rel="canonical">`; fixes `og:type` from `"article"` to `"website"`; fixes a double-slash bug in `og:url` (the old `siteAddress` had a trailing `/` and `router.asPath` always starts with `/`)
- **Layout**: threads `title` and `description` props through to `Meta` so each page controls its own metadata
- **All pages**: every route now has a unique, meaningful browser title, meta description, and Open Graph / Twitter metadata — `index`, `match`, `teams`, `summary`, `scoreboard`, `dashboard`, `account`, `seasons/index`, `seasons/[id]`, `auth/signin`
- **`pages/auth/signin.tsx`**: uses no Layout, so a bare `<Head>` is added directly
- **`pages/seasons/[id].tsx`**: passes the dynamic season name as the `title` prop once loaded; loading/not-found states use appropriate fallback titles
- **`pages/seasons/index.tsx`**: adds a visually-hidden `<label>` associated with the "season name" input so screen readers can identify the field
- **`pages/match.tsx` — BowlerListItem**: converts `styled.div` with `onClick` to `styled.button`, making the bowler picker natively keyboard-accessible (focusable, activatable with Enter/Space, correct ARIA semantics); the `disabled` HTML attribute is used for the just-bowled state so browsers handle focus prevention and click suppression natively
- **MilestoneToast**: adds `role="status"` + `aria-live="polite"` + `aria-atomic="true"` so milestone announcements (e.g. "50 up!") are read aloud by screen readers when they appear

## Test plan

- [ ] Each page should show a unique `<title>` in the browser tab and in page source
- [ ] Open Graph preview (e.g. via a link preview tool) should show page-specific titles and descriptions
- [ ] Keyboard navigation: tab into the bowler picker list on the match page, verify each bowler row is focusable and activatable with Enter/Space; verify the just-bowled bowler is skipped (disabled)
- [ ] Screen reader: milestone toast (e.g. 50 runs) should be announced when it appears
- [ ] `<label for="season-name">` correctly associates with the season name input (visible in browser accessibility tree)
- [ ] Canonical URL in page source should match the page's own URL without trailing double-slash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cy2bJY6LsBzyE4NhRQsD2F

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy2bJY6LsBzyE4NhRQsD2F)_