### PR TITLE
Security: validate localStorage shape before loading game data

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -21,7 +21,12 @@
       "Bash(yarn audit *)",
       "Bash(git merge *)",
       "Bash(git stash *)",
-      "Bash(git fetch *)"
+      "Bash(git fetch *)",
+      "Bash(gh issue *)",
+      "Bash(npx tsc *)",
+      "Bash(npx jest *)",
+      "Bash(git pull *)",
+      "Bash(git rm *)"
     ]
   }
 }

--- a/__tests__/pages/index.spec.tsx
+++ b/__tests__/pages/index.spec.tsx
@@ -78,7 +78,7 @@ describe('Index page', () => {
     });
 
     it('loads saved game, calls setGameScore, and navigates to /match', () => {
-      const savedGame = [{ name: 'Team A' }, { name: 'Team B' }];
+      const savedGame = [{ name: 'Team A', players: [] }, { name: 'Team B', players: [] }];
       localStorage.setItem('gameData', JSON.stringify(savedGame));
       renderIndex();
       fireEvent.click(screen.getByRole('button', { name: /resume saved match/i }));

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,6 +9,7 @@ import defaultPlayers from "../components/core/players";
 import Layout from "../components/layout/layout";
 import PitchDiagram from "../components/pitch/pitch-diagram";
 import { useGameScore } from "../context/GameScoreContext";
+import type { GameScore } from "../context/GameScoreContext";
 
 if (process.env.NODE_ENV === "development" && typeof window !== "undefined") {
   import("accented").then(({ accented }) => {
@@ -39,7 +40,7 @@ const Index: React.FC = () => {
         setError("Saved game data is corrupted");
         return;
       }
-      setGameScore(parsedGameData);
+      setGameScore(parsedGameData as GameScore);
       router.push("/match");
     } catch {
       setError("Saved game data is corrupted");

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -31,6 +31,14 @@ const Index: React.FC = () => {
     }
     try {
       const parsedGameData = JSON.parse(gameData);
+      if (
+        !Array.isArray(parsedGameData) ||
+        parsedGameData.length !== 2 ||
+        !parsedGameData.every((team) => Array.isArray(team?.players))
+      ) {
+        setError("Saved game data is corrupted");
+        return;
+      }
       setGameScore(parsedGameData);
       router.push("/match");
     } catch {


### PR DESCRIPTION
## Summary
- Adds a structural guard in `loadGame()` (`pages/index.tsx`) before passing parsed localStorage data to `setGameScore`
- Checks the data is an array of exactly 2 items, each with a `players` array — corrupted or manually-edited localStorage now shows an error instead of silently breaking the app
- Closes #341 (localStorage validation item; Permissions-Policy header was already shipped in #343)

## Test plan
- [ ] Start a new match and save progress, then resume — game loads correctly
- [ ] Manually corrupt `gameData` in localStorage (e.g. set it to `[{}]` or `"broken"`) and click Resume — should show "Saved game data is corrupted" error
- [ ] All existing tests pass (`yarn jest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)