### PR TITLE
perf: replace raw img tags with next/image and move season data fetching to SSR

### DIFF
--- a/components/auth/UserMenu.tsx
+++ b/components/auth/UserMenu.tsx
@@ -1,6 +1,7 @@
 import { useSession, signOut } from 'next-auth/react';
 import { useState, useRef, useEffect } from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
 import styled from '@emotion/styled';
 
 export default function UserMenu() {
@@ -37,8 +38,7 @@ export default function UserMenu() {
     <Wrapper ref={ref}>
       <Avatar onClick={() => setIsOpen(!isOpen)} aria-label="User menu" aria-expanded={isOpen}>
         {session.user?.image ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img src={session.user.image} alt={session.user.name ?? ''} width={32} height={32} />
+          <Image src={session.user.image} alt={session.user.name ?? ''} width={32} height={32} style={{ objectFit: 'cover' }} />
         ) : (
           initials
         )}

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,14 @@ module.exports = {
     // Enables the styled-components SWC transform
     styledComponents: true
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '*.googleusercontent.com',
+      },
+    ],
+  },
   async headers() {
     return [
       {

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 import { useSession } from "next-auth/react";
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { useRouter } from "next/router";
 import Layout from "../components/layout/layout";
 import SaveCard from "../components/saves/SaveCard";
@@ -160,12 +161,12 @@ export default function DashboardPage() {
         <AccountSection>
           <Avatar>
             {session.user?.image ? (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
+              <Image
                 src={session.user.image}
                 alt={session.user.name ?? ""}
                 width={56}
                 height={56}
+                style={{ objectFit: "cover" }}
               />
             ) : (
               <AvatarInitials>

--- a/pages/seasons/[id].tsx
+++ b/pages/seasons/[id].tsx
@@ -1,10 +1,12 @@
 import styled from '@emotion/styled';
-import { useSession } from 'next-auth/react';
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/router';
+import type { GetServerSideProps } from 'next';
+import { getServerSession } from 'next-auth/next';
 import Link from 'next/link';
 import Layout from '../../components/layout/layout';
 import SaveCard from '../../components/saves/SaveCard';
+import { authOptions } from '../../lib/authOptions';
+import { getUserTier } from '../../lib/subscription';
+import { prisma } from '../../lib/prisma';
 
 type SaveSummary = {
   id: string;
@@ -23,73 +25,11 @@ type SeasonDetail = {
   gameSaves: SaveSummary[];
 };
 
-export default function SeasonDetailPage() {
-  const { data: session } = useSession();
-  const router = useRouter();
-  const { id } = router.query as { id: string };
+type PageProps = {
+  season: SeasonDetail;
+};
 
-  const [season, setSeason] = useState<SeasonDetail | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [notFound, setNotFound] = useState(false);
-
-  useEffect(() => {
-    if (!session || !id) return;
-    fetch(`/api/seasons/${id}`)
-      .then((r) => {
-        if (r.status === 404 || r.status === 403) {
-          setNotFound(true);
-          return null;
-        }
-        return r.json();
-      })
-      .then((data) => {
-        if (data) setSeason(data as SeasonDetail);
-      })
-      .finally(() => setLoading(false));
-  }, [session, id]);
-
-  if (!session) {
-    return (
-      <Layout
-        title="Season"
-        description="View match saves for this cricket season."
-      >
-        <PageWrapper>
-          <p>
-            Please <Link href="/auth/signin">sign in</Link> to view this season.
-          </p>
-        </PageWrapper>
-      </Layout>
-    );
-  }
-
-  if (loading) {
-    return (
-      <Layout
-        title="Season"
-        description="View match saves for this cricket season."
-      >
-        <PageWrapper>
-          <EmptyState>Loading season…</EmptyState>
-        </PageWrapper>
-      </Layout>
-    );
-  }
-
-  if (notFound || !season) {
-    return (
-      <Layout
-        title="Season not found"
-        description="This season could not be found."
-      >
-        <PageWrapper>
-          <EmptyState>Season not found.</EmptyState>
-          <BackLink href="/seasons">← Back to seasons</BackLink>
-        </PageWrapper>
-      </Layout>
-    );
-  }
-
+export default function SeasonDetailPage({ season }: PageProps) {
   return (
     <Layout
       title={season.name}
@@ -113,6 +53,51 @@ export default function SeasonDetailPage() {
     </Layout>
   );
 }
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+  const session = await getServerSession(context.req, context.res, authOptions);
+  if (!session) {
+    return { redirect: { destination: '/auth/signin', permanent: false } };
+  }
+
+  const userId = session.user.id;
+  const tier = await getUserTier(userId);
+  if (tier === 'free') {
+    return { redirect: { destination: '/seasons', permanent: false } };
+  }
+
+  const { id } = context.params as { id: string };
+  const season = await prisma.season.findUnique({ where: { id } });
+  if (!season || season.userId !== userId) {
+    return { notFound: true };
+  }
+
+  type DbSave = { id: string; title: string | null; createdAt: Date; completed: boolean; seasonId: string | null };
+  const saves = (await prisma.gameSave.findMany({
+    where: { seasonId: id },
+    select: { id: true, title: true, createdAt: true, completed: true, seasonId: true },
+    orderBy: { createdAt: 'desc' },
+  })) as DbSave[];
+
+  return {
+    props: {
+      season: {
+        id: season.id as string,
+        name: season.name as string,
+        description: season.description as string | null,
+        createdAt: (season.createdAt as Date).toISOString(),
+        updatedAt: (season.updatedAt as Date).toISOString(),
+        gameSaves: saves.map((s) => ({
+          id: s.id,
+          title: s.title,
+          completed: s.completed,
+          seasonId: s.seasonId,
+          createdAt: s.createdAt.toISOString(),
+        })),
+      },
+    },
+  };
+};
 
 const PageWrapper = styled.main`
   width: 100%;

--- a/pages/seasons/index.tsx
+++ b/pages/seasons/index.tsx
@@ -1,11 +1,13 @@
 import styled from '@emotion/styled';
-import { useSession } from 'next-auth/react';
-import { useEffect, useState } from 'react';
-import Link from 'next/link';
+import type { GetServerSideProps } from 'next';
+import { getServerSession } from 'next-auth/next';
+import { useState } from 'react';
 import Layout from '../../components/layout/layout';
 import SeasonCard from '../../components/seasons/SeasonCard';
 import UpgradeCTA from '../../components/premium/UpgradeCTA';
-import { useAccount } from '../../context/AccountContext';
+import { authOptions } from '../../lib/authOptions';
+import { getUserTier } from '../../lib/subscription';
+import { prisma } from '../../lib/prisma';
 
 type SeasonSummary = {
   id: string;
@@ -16,25 +18,17 @@ type SeasonSummary = {
   updatedAt: string;
 };
 
-export default function SeasonsPage() {
-  const { data: session } = useSession();
-  const { tier, isLoading: accountLoading } = useAccount();
-  const [seasons, setSeasons] = useState<SeasonSummary[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [seasonsError, setSeasonsError] = useState(false);
+type PageProps = {
+  tier: 'free' | 'premium';
+  seasons: SeasonSummary[];
+};
+
+export default function SeasonsPage({ tier, seasons: initialSeasons }: PageProps) {
+  const [seasons, setSeasons] = useState<SeasonSummary[]>(initialSeasons);
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
   const [newName, setNewName] = useState('');
   const [formOpen, setFormOpen] = useState(false);
-
-  useEffect(() => {
-    if (!session || tier !== 'premium') return;
-    fetch('/api/seasons')
-      .then((r) => { if (!r.ok) throw new Error('fetch failed'); return r.json(); })
-      .then((data) => setSeasons(data))
-      .catch(() => setSeasonsError(true))
-      .finally(() => setLoading(false));
-  }, [session, tier]);
 
   const createSeason = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -61,22 +55,7 @@ export default function SeasonsPage() {
     }
   };
 
-  if (!session) {
-    return (
-      <Layout
-        title="Seasons"
-        description="Create and manage your T20 cricket seasons to group and track your matches."
-      >
-        <PageWrapper>
-          <p>
-            Please <Link href="/auth/signin">sign in</Link> to view your seasons.
-          </p>
-        </PageWrapper>
-      </Layout>
-    );
-  }
-
-  if (!accountLoading && tier === 'free') {
+  if (tier === 'free') {
     return (
       <Layout
         title="Seasons"
@@ -122,11 +101,7 @@ export default function SeasonsPage() {
           </Form>
         )}
 
-        {loading ? (
-          <EmptyState>Loading seasons…</EmptyState>
-        ) : seasonsError ? (
-          <ErrorMessage role="alert">Could not load seasons. Please refresh.</ErrorMessage>
-        ) : seasons.length === 0 ? (
+        {seasons.length === 0 ? (
           <EmptyState>No seasons yet. Create one to group your games.</EmptyState>
         ) : (
           <SeasonsGrid>
@@ -139,6 +114,41 @@ export default function SeasonsPage() {
     </Layout>
   );
 }
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+  const session = await getServerSession(context.req, context.res, authOptions);
+  if (!session) {
+    return { redirect: { destination: '/auth/signin', permanent: false } };
+  }
+
+  const userId = session.user.id;
+  const tier = await getUserTier(userId);
+
+  if (tier === 'free') {
+    return { props: { tier: 'free', seasons: [] } };
+  }
+
+  type DbSeasonRow = { _count: { gameSaves: number }; id: string; name: string; description: string | null; createdAt: Date; updatedAt: Date };
+  const seasons = (await prisma.season.findMany({
+    where: { userId },
+    include: { _count: { select: { gameSaves: true } } },
+    orderBy: { createdAt: 'desc' },
+  })) as DbSeasonRow[];
+
+  return {
+    props: {
+      tier: 'premium',
+      seasons: seasons.map(({ _count, id, name, description, createdAt, updatedAt }) => ({
+        id,
+        name,
+        description,
+        gameCount: _count.gameSaves,
+        createdAt: createdAt.toISOString(),
+        updatedAt: updatedAt.toISOString(),
+      })),
+    },
+  };
+};
 
 const PageWrapper = styled.main`
   width: 100%;


### PR DESCRIPTION
## Summary

- Replace two raw `<img>` tags with Next.js `<Image>` component for automatic optimisation, lazy loading, and correct format selection
- Add `images.remotePatterns` to `next.config.js` to allow Google OAuth avatar URLs through Next.js image optimisation (previously the images were served raw with no CDN optimisation)
- Convert `pages/seasons/[id].tsx` from client-side `useEffect` fetch to `getServerSideProps`, eliminating the `router.query` hydration race condition and delivering fully server-rendered HTML on first request
- Convert `pages/seasons/index.tsx` from client-side `useEffect` fetch to `getServerSideProps`, with the tier check also moved server-side; create mutations (POST `/api/seasons`) remain client-side with optimistic local state updates

## Changes

### `next.config.js`
Added `images.remotePatterns` for `*.googleusercontent.com` so that Google OAuth profile photos can be served through Next.js image optimisation. Without this, `next/image` would refuse to handle external avatar URLs.

### `components/auth/UserMenu.tsx` · `pages/dashboard.tsx`
Replaced raw `<img>` tags (which bypassed all Next.js image optimisation and triggered the `@next/next/no-img-element` lint rule) with `<Image>` from `next/image`. Both tags displayed user profile photos from Google OAuth; they now benefit from lazy loading, WebP/AVIF conversion, and responsive srcsets.

### `pages/seasons/[id].tsx`
Rewrote from a client-fetched page to a fully SSR page. Before: the component mounted, read `router.query.id` (which is `undefined` on the first hydration pass), waited for a second render, then triggered a `useEffect` fetch. After: `getServerSideProps` receives `context.params.id` reliably, queries Prisma directly (same logic as the API route), and returns fully typed props. Unauthenticated requests redirect server-side; 404/403 season lookups return `{ notFound: true }`.

### `pages/seasons/index.tsx`
Rewrote from a client-fetched page to a fully SSR page. Before: the page rendered twice (once empty, once with data) because data was loaded in a `useEffect` that depended on both `session` and `tier` from context. After: `getServerSideProps` checks session, resolves tier via `getUserTier`, queries seasons directly, and returns them as props. The "create season" form still posts client-side and updates local state optimistically, so the UX is unchanged. The `useAccount` and `useSession` context hooks are no longer needed on this page.

## Notes on `yarn lint`

`yarn lint` runs `tsc --noEmit && biome lint .`. In this environment the Prisma engine binary cannot be downloaded (network egress policy), so `prisma generate` cannot run and `@prisma/client` exports no types. This causes pre-existing TypeScript errors in `lib/prisma.ts`, `pages/dashboard.tsx`, `components/saves/SaveCard.tsx`, `context/AccountContext.tsx`, and the `pages/api/` routes — none of which were introduced by this PR. The changes in this PR do not add any new TypeScript errors (explicit type annotations were added to Prisma query results to avoid implicit-any in the new `getServerSideProps` functions). Biome lint passes cleanly for all changed files. The CI pipeline, which runs `prisma generate` as part of `postinstall`, will resolve the TypeScript errors there.

## Test plan

- [ ] Visit `/seasons` as a logged-in premium user — data loads immediately on first render with no flash of empty state
- [ ] Visit `/seasons/<id>` as a logged-in premium user — season name and saves appear without a loading spinner
- [ ] Visit `/seasons/<id>` as a free-tier user — should redirect to `/seasons`
- [ ] Visit `/seasons` or `/seasons/<id>` while logged out — should redirect to `/auth/signin`
- [ ] Visit `/seasons/<id>` with an invalid or other user's season ID — should return a 404 page
- [ ] Check avatar images in the nav `UserMenu` and on the `/dashboard` page — should load via `/_next/image` rather than directly from Google's CDN
- [ ] Confirm the "Create season" form on `/seasons` still works and adds new seasons to the list optimistically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WX2iobQyuaUm8KcuMPZ9WV

---
_Generated by [Claude Code](https://claude.ai/code/session_01WX2iobQyuaUm8KcuMPZ9WV)_