### PR TITLE
fix(a11y): accessibility and SEO improvements

### DIFF
--- a/components/auth/UserMenu.tsx
+++ b/components/auth/UserMenu.tsx
@@ -36,7 +36,7 @@ export default function UserMenu() {
 
   return (
     <Wrapper ref={ref}>
-      <Avatar onClick={() => setIsOpen(!isOpen)} aria-label="User menu" aria-expanded={isOpen}>
+      <Avatar onClick={() => setIsOpen(!isOpen)} aria-label="User menu" aria-expanded={isOpen} aria-haspopup="true">
         {session.user?.image ? (
           <Image src={session.user.image} alt={session.user.name ?? ''} width={32} height={32} style={{ objectFit: 'cover' }} />
         ) : (
@@ -44,14 +44,14 @@ export default function UserMenu() {
         )}
       </Avatar>
       {isOpen && (
-        <Dropdown>
-          <DropdownLink href="/dashboard" onClick={() => setIsOpen(false)}>
+        <Dropdown role="menu">
+          <DropdownLink href="/dashboard" role="menuitem" onClick={() => setIsOpen(false)}>
             Dashboard
           </DropdownLink>
-          <DropdownLink href="/account" onClick={() => setIsOpen(false)}>
+          <DropdownLink href="/account" role="menuitem" onClick={() => setIsOpen(false)}>
             Account
           </DropdownLink>
-          <DropdownButton onClick={() => signOut({ callbackUrl: '/' })}>Sign out</DropdownButton>
+          <DropdownButton role="menuitem" onClick={() => signOut({ callbackUrl: '/' })}>Sign out</DropdownButton>
         </Dropdown>
       )}
     </Wrapper>

--- a/components/core/buttons.tsx
+++ b/components/core/buttons.tsx
@@ -92,6 +92,11 @@ export const SquareButton = styled.button`
     outline: 0;
   }
 
+  &:focus-visible {
+    outline: 3px solid #005fcc;
+    outline-offset: 2px;
+  }
+
   &:disabled {
     background-color: #ccc;
     border-color: #ccc;

--- a/components/header/header.tsx
+++ b/components/header/header.tsx
@@ -1,11 +1,12 @@
 import styled from '@emotion/styled';
+import Link from 'next/link';
 import type React from 'react';
 import Nav from '../nav/nav';
 
 const Header: React.FC = () => {
   return (
     <StyledHeader>
-      <StyledHeading>20Twenty Score</StyledHeading>
+      <StyledHeading href="/" aria-label="20Twenty Score — go to home">20Twenty Score</StyledHeading>
       <Nav />
     </StyledHeader>
   );
@@ -24,7 +25,7 @@ const StyledHeader = styled.header`
   }
 `;
 
-const StyledHeading = styled.p`
+const StyledHeading = styled(Link)`
   color: #fff;
   margin: 0;
   padding: 1rem 0.5rem;

--- a/components/meta/meta.tsx
+++ b/components/meta/meta.tsx
@@ -10,7 +10,7 @@ const SITE_NAME = '20Twenty Score';
 const SITE_URL = 'https://20-twenty-score.vercel.app';
 const DEFAULT_DESCRIPTION =
   'Track your T20 cricket match ball by ball — runs, wickets, extras, and live run rates.';
-const OG_IMAGE = '/images/temp-seo-image.jpg';
+const OG_IMAGE = `${SITE_URL}/images/temp-seo-image.jpg`;
 
 export default function Meta({ title, description }: Props) {
   const router = useRouter();
@@ -44,7 +44,6 @@ export default function Meta({ title, description }: Props) {
       <meta name="twitter:title" content={pageTitle} />
       <meta name="twitter:description" content={pageDescription} />
       <meta name="twitter:image" content={OG_IMAGE} />
-      <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
     </Head>
   );
 }

--- a/components/nav/nav.spec.tsx
+++ b/components/nav/nav.spec.tsx
@@ -38,7 +38,7 @@ describe('Nav Component', () => {
     window.dispatchEvent(new Event('resize'));
     render(<Nav />);
 
-    const expandedMenu = screen.getByLabelText('Expanded Menu');
+    const expandedMenu = screen.getByLabelText('Main navigation');
     expect(expandedMenu).not.toHaveClass('open');
 
     act(() => {

--- a/components/nav/nav.tsx
+++ b/components/nav/nav.tsx
@@ -21,24 +21,24 @@ export default function Nav() {
         <span></span>
         <span></span>
       </BurgerButton>
-      <ul id="mobile-nav-menu" className={isDropdownOpen ? 'open' : ''} aria-label="Expanded Menu">
+      <ul id="mobile-nav-menu" className={isDropdownOpen ? 'open' : ''} aria-label="Main navigation">
         <li>
-          <Link href="/" className={isActive('/') ? 'active' : ''}>
+          <Link href="/" className={isActive('/') ? 'active' : ''} aria-current={isActive('/') ? 'page' : undefined}>
             Home
           </Link>
         </li>
         <li>
-          <Link href="/match" className={isActive('/match') ? 'active' : ''}>
+          <Link href="/match" className={isActive('/match') ? 'active' : ''} aria-current={isActive('/match') ? 'page' : undefined}>
             Match
           </Link>
         </li>
         <li>
-          <Link href="/teams" className={isActive('/teams') ? 'active' : ''}>
+          <Link href="/teams" className={isActive('/teams') ? 'active' : ''} aria-current={isActive('/teams') ? 'page' : undefined}>
             Teams
           </Link>
         </li>
         <li>
-          <Link href="/summary" className={isActive('/summary') ? 'active' : ''}>
+          <Link href="/summary" className={isActive('/summary') ? 'active' : ''} aria-current={isActive('/summary') ? 'page' : undefined}>
             Summary
           </Link>
         </li>

--- a/components/player/player.spec.tsx
+++ b/components/player/player.spec.tsx
@@ -82,7 +82,7 @@ describe('Player', () => {
       oversBowled: 0, runsConceded: 0
     };
     render(<Player {...props} />);
-    expect(screen.getByTitle('Current striker')).toBeVisible();
+    expect(screen.getByAltText('Current striker')).toBeVisible();
   });
 
   it('should not show current striker icon if player is not batting', () => {
@@ -112,6 +112,6 @@ describe('Player', () => {
       oversBowled: 0, runsConceded: 0
     };
     render(<Player {...props} />);
-    expect(screen.getByTitle('Current non striker')).toBeVisible();
+    expect(screen.getByAltText('Current non-striker')).toBeVisible();
   });
 });

--- a/components/player/player.tsx
+++ b/components/player/player.tsx
@@ -70,6 +70,7 @@ export const Player = ({
               ref={inputRef}
               type="text"
               value={name}
+              aria-label={`Edit name for ${name}`}
               onChange={handlePlayerNameChange}
               onKeyDown={handleKeyDown}
             />
@@ -90,8 +91,7 @@ export const Player = ({
       <p>Overs Bowled: {oversBowled}</p>
       {currentStriker && (
         <Image
-          alt=""
-          title="Current striker"
+          alt="Current striker"
           width={32}
           height={32}
           src="/icons/png/004-cricket-player.png"
@@ -99,8 +99,7 @@ export const Player = ({
       )}
       {currentNonStriker && (
         <Image
-          alt=""
-          title="Current non striker"
+          alt="Current non-striker"
           width={32}
           height={32}
           src="/icons/png/010-helmet.png"

--- a/components/saves/SaveCard.tsx
+++ b/components/saves/SaveCard.tsx
@@ -34,7 +34,10 @@ export default function SaveCard({ id, title, createdAt, completed, seasonId, se
       </Card>
       {seasons && onSeasonChange && (
         <SeasonRow onClick={(e) => e.stopPropagation()}>
-          <SeasonSelect value={seasonId ?? ''} onChange={handleSeasonChange}>
+          <label htmlFor={`season-select-${id}`} className="visually-hidden">
+            Assign to season
+          </label>
+          <SeasonSelect id={`season-select-${id}`} value={seasonId ?? ''} onChange={handleSeasonChange}>
             <option value="">No season</option>
             {seasons.map((s) => (
               <option key={s.id} value={s.id}>{s.name}</option>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,6 @@
 import { css, Global } from '@emotion/react';
 import type { AppProps } from 'next/app';
 import { useEffect } from 'react';
-import Head from 'next/head';
 import { Analytics } from '@vercel/analytics/next';
 import { SessionProvider } from 'next-auth/react';
 import { AccountProvider } from '../context/AccountContext';
@@ -24,7 +23,6 @@ export default function App({ Component, pageProps: { session, ...pageProps } }:
     <SessionProvider session={session}>
     <AccountProvider>
     <GameProvider>
-      <Head><title>20Twenty Score</title></Head>
       <GameStatePersister />
       <Global
         styles={css`

--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -1,9 +1,9 @@
 import { signIn } from 'next-auth/react';
 import styled from '@emotion/styled';
-import Head from 'next/head';
 import { PrimaryButton } from '../../components/core/buttons';
+import Meta from '../../components/meta/meta';
 
-const Container = styled.div`
+const Container = styled.main`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -37,10 +37,10 @@ const ButtonGroup = styled.div`
 export default function SignIn() {
   return (
     <Container>
-      <Head>
-        <title>Sign In | 20Twenty Score</title>
-        <meta name="description" content="Sign in to 20Twenty Score to save your games and manage your cricket seasons." />
-      </Head>
+      <Meta
+        title="Sign In"
+        description="Sign in to 20Twenty Score to save your games and manage your cricket seasons."
+      />
       <Title>20Twenty Score</Title>
       <Subtitle>Sign in to save your games and seasons</Subtitle>
       <ButtonGroup>

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -153,7 +153,7 @@ export default function DashboardPage() {
     >
       <PageWrapper>
         {checkoutSuccess && (
-          <CheckoutBanner>
+          <CheckoutBanner role="status">
             Welcome to Premium! Your subscription is now active.
           </CheckoutBanner>
         )}


### PR DESCRIPTION
## Summary

Accessibility and SEO audit for 2026-07-02 (Thursday category). Fixes span WCAG 2.4.7 focus visibility, ARIA labelling, semantic HTML, navigation landmarks, and Open Graph metadata.

### Keyboard & Focus
- **`SquareButton` focus ring restored** — `outline: 0` was wiping the browser's visible focus indicator for keyboard/switch-access users. Replaced with `&:focus-visible` that shows a 3 px blue ring, leaving mouse click unaffected.
- **Active nav links get `aria-current="page"`** — screen readers can now announce the current page without relying solely on a CSS class.

### ARIA & Screen Reader Labels
- **Player name edit `<input>` labelled** — was rendered with no `<label>`, `aria-label`, or `aria-labelledby`. Added `aria-label="Edit name for {name}"`.
- **Informative player status images** — `alt=""` (decorative) changed to `alt="Current striker"` / `alt="Current non-striker"` since these images convey meaningful state.
- **Season `<select>` in SaveCard** — added a visually-hidden `<label>` linked via `htmlFor`/`id`; previously announced as an unlabelled combobox.
- **UserMenu dropdown ARIA** — added `aria-haspopup="true"` to the trigger button, `role="menu"` to the dropdown container, and `role="menuitem"` to each link and button inside.
- **Checkout success banner** — added `role="status"` so screen readers announce the dynamically injected "Welcome to Premium!" message (matches the existing `role="alert"` pattern used for errors).
- **Nav `<ul>` label corrected** — changed `aria-label="Expanded Menu"` (inaccurate, always the same) to `aria-label="Main navigation"`.

### Semantic HTML & Landmarks
- **Site header brand name is now a link** — `StyledHeading` was a `styled.p`; changed to `styled(Link)` pointing to `/` so keyboard users and screen reader users can reach the home page from the header (standard convention).
- **Sign-in page gets a `<main>` landmark** — `Container` was `styled.div`; changed to `styled.main` so landmark navigation works on the page. Also replaced the inline `<Head>` block with the shared `<Meta>` component so the sign-in page gains full OG/Twitter card tags.

### SEO & Meta
- **OG/Twitter image URLs made absolute** — `og:image` and `twitter:image` were relative paths (`/images/...`). Social unfurlers (Facebook, Twitter/X, Slack) require absolute URLs; fixed to use `${SITE_URL}/images/...`.
- **RSS `<link>` removed** — pointed to `/feed.xml` which does not exist. Every page was emitting a link to a 404.
- **Duplicate `<title>` in `_app.tsx` removed** — `_app.tsx` set `<title>20Twenty Score</title>` globally, duplicating what the `<Meta>` component already handles on every page. Removed; the unused `next/head` import was also removed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtHntrCureMHCyzjRpqaGG)_