### PR TITLE
fix(a11y): improve accessibility across scoring, match, and dashboard pages

### DIFF
--- a/components/pitch/pitch-diagram.tsx
+++ b/components/pitch/pitch-diagram.tsx
@@ -7,6 +7,7 @@ export default function PitchDiagram() {
       viewBox="0 0 220 220"
       width="220"
       height="220"
+      role="img"
       aria-label="Cricket ground diagram"
       style={{ display: 'block' }}>
       {/* Outfield */}

--- a/components/saves/SaveCard.tsx
+++ b/components/saves/SaveCard.tsx
@@ -118,9 +118,11 @@ const SeasonSelect = styled.select`
   background: transparent;
   cursor: pointer;
   width: 100%;
-  outline: none;
 
   &:focus {
     color: #1a1a1a;
+    outline: 2px solid #005fcc;
+    outline-offset: 2px;
+    border-radius: 2px;
   }
 `;

--- a/components/scoring/scoring.tsx
+++ b/components/scoring/scoring.tsx
@@ -192,31 +192,32 @@ const Scoring = ({ setSelectBowler }: ScoringProps) => {
           ↩ Undo
         </UndoButton>
       </ScoringFooter>
-      {awaitingMethodOfWicket && (
-        <>
-          {' '}
-          <ScoringHeader>
-            <ScoringTitle>Method of wicket</ScoringTitle>
-          </ScoringHeader>
-          <ScoringGrid>
-            <SquareButton
-              disabled={endOfGame()}
-              onClick={() => handleScoreClick(currentStriker?.index, 0, 'Wicket', 'LBW')}>
-              LBW
-            </SquareButton>
-            <SquareButton
-              disabled={endOfGame()}
-              onClick={() => handleScoreClick(currentStriker?.index, 0, 'Wicket', 'Caught')}>
-              Caught
-            </SquareButton>
-            <SquareButton
-              disabled={endOfGame()}
-              onClick={() => handleScoreClick(currentStriker?.index, 0, 'Wicket', 'Run Out')}>
-              Run Out
-            </SquareButton>
-          </ScoringGrid>
-        </>
-      )}
+      <MethodOfWicketRegion aria-live="polite">
+        {awaitingMethodOfWicket && (
+          <>
+            <ScoringHeader>
+              <ScoringTitle>Method of wicket</ScoringTitle>
+            </ScoringHeader>
+            <ScoringGrid>
+              <SquareButton
+                disabled={endOfGame()}
+                onClick={() => handleScoreClick(currentStriker?.index, 0, 'Wicket', 'LBW')}>
+                LBW
+              </SquareButton>
+              <SquareButton
+                disabled={endOfGame()}
+                onClick={() => handleScoreClick(currentStriker?.index, 0, 'Wicket', 'Caught')}>
+                Caught
+              </SquareButton>
+              <SquareButton
+                disabled={endOfGame()}
+                onClick={() => handleScoreClick(currentStriker?.index, 0, 'Wicket', 'Run Out')}>
+                Run Out
+              </SquareButton>
+            </ScoringGrid>
+          </>
+        )}
+      </MethodOfWicketRegion>
     </HomeContainer>
   );
 };
@@ -326,6 +327,10 @@ const ButtonSub = styled.span`
   text-transform: uppercase;
   color: inherit;
   margin-top: 0.2rem;
+`;
+
+const MethodOfWicketRegion = styled.div`
+  width: 100%;
 `;
 
 const ScoringGrid = styled.div`

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -208,7 +208,7 @@ export default function DashboardPage() {
         {saveError && saveError !== "FREE_LIMIT_REACHED" && (
           <ErrorMessage role="alert">{saveError}</ErrorMessage>
         )}
-        {saveSuccess && <SuccessMessage>Game saved!</SuccessMessage>}
+        {saveSuccess && <SuccessMessage role="status">Game saved!</SuccessMessage>}
 
         {savesLoading ? (
           <EmptyState>Loading saves…</EmptyState>

--- a/pages/match.tsx
+++ b/pages/match.tsx
@@ -193,7 +193,7 @@ const MatchPage: React.FC = () => {
         <MatchPanel>
           <TeamSide>
             <StatusLabel>
-              <Ball color={teamA?.currentBattingTeam ? "#b83320" : "#aaa"} />
+              <Ball color={teamA?.currentBattingTeam ? "#b83320" : "#aaa"} aria-hidden="true" />
               {teamA?.currentBattingTeam ? "Batting" : "Bowling"}
             </StatusLabel>
             <TeamName>{teamA?.name}</TeamName>
@@ -224,7 +224,7 @@ const MatchPage: React.FC = () => {
           <TeamSide align="right">
             <StatusLabel reverse>
               {team1?.currentBattingTeam ? "Batting" : "Bowling"}
-              <Ball color={team1?.currentBattingTeam ? "#b83320" : "#aaa"} />
+              <Ball color={team1?.currentBattingTeam ? "#b83320" : "#aaa"} aria-hidden="true" />
             </StatusLabel>
             <TeamName>{team1?.name}</TeamName>
             <TeamScore>
@@ -245,7 +245,7 @@ const MatchPage: React.FC = () => {
             </TeamOvers>
           </TeamSide>
         </MatchPanel>
-        <LiveBar>
+        <LiveBar aria-live="polite" aria-label="Live match stats">
           <LiveAction>
             <LiveLabel>Last ball</LiveLabel>
             <LiveValue>{formatLatestAction()}</LiveValue>
@@ -410,7 +410,7 @@ const MatchPage: React.FC = () => {
                   <SplitStat>
                     {currentRunRate}
                   </SplitStat>
-                  <GreenBarTrack>
+                  <GreenBarTrack aria-hidden="true">
                     <GreenBar
                       fill={Math.min(parseFloat(currentRunRate) / MAX_RUN_RATE_DISPLAY, 1)}
                     />
@@ -449,7 +449,7 @@ const MatchPage: React.FC = () => {
                         <>
                           <BoxMeta>Required rate</BoxMeta>
                           <SplitStat>{requiredRate}</SplitStat>
-                          <RedBarTrack>
+                          <RedBarTrack aria-hidden="true">
                             <RedBar fill={Number.isNaN(rrFill) ? 0 : rrFill} />
                           </RedBarTrack>
                           <RunsSummaryDivider />
@@ -466,7 +466,7 @@ const MatchPage: React.FC = () => {
                       <>
                         <BoxMeta>Projected</BoxMeta>
                         <SplitStat>{projected}</SplitStat>
-                        <RedBarTrack>
+                        <RedBarTrack aria-hidden="true">
                           <RedBar fill={Math.min(projected / MAX_PROJECTED_SCORE, 1)} />
                         </RedBarTrack>
                         <RunsSummaryDivider />

--- a/pages/summary.tsx
+++ b/pages/summary.tsx
@@ -177,6 +177,9 @@ const SummaryPage: React.FC = () => {
             <CopyButton onClick={copyScorecard} data-analytics="copy-scorecard">
               {copied ? 'Copied ✓' : 'Copy scorecard'}
             </CopyButton>
+            <span role="status" className="visually-hidden">
+              {copied ? 'Scorecard copied to clipboard' : ''}
+            </span>
           </CopySection>
 
           {session && (
@@ -193,7 +196,7 @@ const SummaryPage: React.FC = () => {
               {saveError && saveError !== 'FREE_LIMIT_REACHED' && (
                 <SaveMessage error role="alert">{saveError}</SaveMessage>
               )}
-              {saveSuccess && <SaveMessage>Saved to cloud!</SaveMessage>}
+              {saveSuccess && <SaveMessage role="status">Saved to cloud!</SaveMessage>}
             </CloudSaveSection>
           )}
         </ResultPanel>


### PR DESCRIPTION
## Summary

Accessibility improvements across six files, targeting screen reader announcements, keyboard focus, and semantic markup.

- **`components/pitch/pitch-diagram.tsx`** — Add `role="img"` to the SVG element. Without it, screen readers may not recognise the element as an image even though `aria-label` is present (WCAG 1.1.1).

- **`pages/match.tsx`** — Three fixes:
  - Add `aria-hidden="true"` to the decorative coloured `Ball` dots in the team status labels; the adjacent "Batting"/"Bowling" text already conveys this information, so the dots are noise for screen readers.
  - Add `aria-live="polite"` and `aria-label="Live match stats"` to the `LiveBar` so score updates (last ball, overs, run rate) are announced to screen reader users after each scoring action.
  - Add `aria-hidden="true"` to all three progress bar tracks (`GreenBarTrack`, both `RedBarTrack` instances); their values are already rendered as readable text above each bar, so the bars themselves are decorative.

- **`components/scoring/scoring.tsx`** — Wrap the method-of-wicket section in a persistent `aria-live="polite"` region. Previously, tapping the "W" button silently changed the UI to a wicket-method picker with no announcement; now screen readers will read out "Method of wicket" when the section appears (WCAG 4.1.3).

- **`pages/dashboard.tsx`** — Add `role="status"` to the "Game saved!" success message. The error counterpart already had `role="alert"`; the success path was missing its live-region counterpart (WCAG 4.1.3).

- **`pages/summary.tsx`** — Two fixes:
  - Add `role="status"` to the "Saved to cloud!" success message, matching the existing `role="alert"` on the error message.
  - Add a visually-hidden `role="status"` span that announces "Scorecard copied to clipboard" when the copy button is activated; the button text changes visually but screen readers do not reliably re-announce button labels on click.

- **`components/saves/SaveCard.tsx`** — Remove `outline: none` from `SeasonSelect` and replace with a visible `2px solid #005fcc` focus ring. The previous rule hid the browser focus indicator entirely, breaking keyboard navigation for users who tab to the season dropdown (WCAG 2.4.7 — Focus Visible).

## Test plan

- [ ] Verify the pitch diagram SVG is announced as "Cricket ground diagram" by a screen reader (VoiceOver / NVDA)
- [ ] Score a ball on the match page and confirm the live bar is read aloud by a screen reader
- [ ] Tap "W" to trigger the method-of-wicket picker and confirm "Method of wicket" is announced
- [ ] Save a game from the dashboard and confirm "Game saved!" is announced without requiring focus to move
- [ ] Copy the scorecard on the summary page and confirm "Scorecard copied to clipboard" is announced
- [ ] Tab to the season dropdown on a save card and confirm a visible focus ring is shown


---
_Generated by [Claude Code](https://claude.ai/code/session_01W3wYTynVGAZEAMmyBU5m8f)_