### PR TITLE
chore(typescript): replace non-null assertions with safer env var handling

### DIFF
--- a/components/premium/UpgradeCTA.tsx
+++ b/components/premium/UpgradeCTA.tsx
@@ -4,7 +4,8 @@ import styled from '@emotion/styled';
 export default function UpgradeCTA() {
   const [loading, setLoading] = useState<'monthly' | 'annual' | null>(null);
 
-  const subscribe = async (priceId: string, plan: 'monthly' | 'annual') => {
+  const subscribe = async (priceId: string | undefined, plan: 'monthly' | 'annual') => {
+    if (!priceId) return;
     setLoading(plan);
     try {
       const res = await fetch('/api/stripe/create-checkout-session', {
@@ -28,7 +29,7 @@ export default function UpgradeCTA() {
           <PriceAmount>£2.99</PriceAmount>
           <PricePeriod>per month</PricePeriod>
           <SubscribeButton
-            onClick={() => subscribe(process.env.NEXT_PUBLIC_STRIPE_MONTHLY_PRICE_ID!, 'monthly')}
+            onClick={() => subscribe(process.env.NEXT_PUBLIC_STRIPE_MONTHLY_PRICE_ID, 'monthly')}
             disabled={loading !== null}
           >
             {loading === 'monthly' ? 'Redirecting…' : 'Subscribe monthly'}
@@ -42,7 +43,7 @@ export default function UpgradeCTA() {
           <PricePeriod>per year</PricePeriod>
           <AnnualBadge>Save 72%</AnnualBadge>
           <SubscribeButton
-            onClick={() => subscribe(process.env.NEXT_PUBLIC_STRIPE_ANNUAL_PRICE_ID!, 'annual')}
+            onClick={() => subscribe(process.env.NEXT_PUBLIC_STRIPE_ANNUAL_PRICE_ID, 'annual')}
             disabled={loading !== null}
           >
             {loading === 'annual' ? 'Redirecting…' : 'Subscribe annually'}

--- a/components/scoring/scoring.tsx
+++ b/components/scoring/scoring.tsx
@@ -35,7 +35,7 @@ const Scoring = ({ setSelectBowler }: ScoringProps) => {
   const currentBowlingTeam = gameScore.find((team) => team.currentBowlingTeam);
 
   if (!currentBattingTeam || !currentBowlingTeam) {
-    return;
+    return null;
   }
 
   const currentBattingTeamIndex = currentBattingTeam.index;

--- a/lib/authOptions.ts
+++ b/lib/authOptions.ts
@@ -2,13 +2,14 @@ import { PrismaAdapter } from '@next-auth/prisma-adapter';
 import GoogleProvider from 'next-auth/providers/google';
 import type { NextAuthOptions } from 'next-auth';
 import { prisma } from './prisma';
+import { requireEnv } from './env';
 
 export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),
   providers: [
     GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID!,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      clientId: requireEnv('GOOGLE_CLIENT_ID'),
+      clientSecret: requireEnv('GOOGLE_CLIENT_SECRET'),
     }),
   ],
   session: {
@@ -19,7 +20,7 @@ export const authOptions: NextAuthOptions = {
   },
   callbacks: {
     session({ session, token }) {
-      session.user.id = token.sub!;
+      session.user.id = token.sub ?? '';
       return session;
     },
   },

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,7 @@
+export function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,11 +1,12 @@
 import { PrismaClient } from "@prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
+import { requireEnv } from "./env";
 
 const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
 
 function createPrismaClient() {
   const adapter = new PrismaPg({
-    connectionString: process.env.DATABASE_URL!,
+    connectionString: requireEnv("DATABASE_URL"),
   });
   return new PrismaClient({ adapter });
 }

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -1,5 +1,6 @@
 import Stripe from 'stripe';
+import { requireEnv } from './env';
 
-export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+export const stripe = new Stripe(requireEnv('STRIPE_SECRET_KEY'), {
   apiVersion: '2026-06-24.dahlia',
 });

--- a/pages/api/stripe/webhook.ts
+++ b/pages/api/stripe/webhook.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import type Stripe from 'stripe';
 import { stripe } from '../../../lib/stripe';
 import { prisma } from '../../../lib/prisma';
+import { requireEnv } from '../../../lib/env';
 
 export const config = { api: { bodyParser: false } };
 
@@ -27,11 +28,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const rawBody = await getRawBody(req);
-  const sig = req.headers['stripe-signature'] as string;
+  const sig = req.headers['stripe-signature'];
+  if (!sig) {
+    return res.status(400).json({ error: 'Missing stripe-signature header' });
+  }
 
   let event: Stripe.Event;
   try {
-    event = stripe.webhooks.constructEvent(rawBody, sig, process.env.STRIPE_WEBHOOK_SECRET!);
+    event = stripe.webhooks.constructEvent(rawBody, sig, requireEnv('STRIPE_WEBHOOK_SECRET'));
   } catch (err) {
     return res.status(400).json({ error: `Webhook signature verification failed: ${err}` });
   }

--- a/pages/summary.tsx
+++ b/pages/summary.tsx
@@ -46,14 +46,14 @@ const SummaryPage: React.FC = () => {
   const [copied, setCopied] = useState(false);
 
   const copyScorecard = async () => {
-    await navigator.clipboard.writeText(formatShareText(gameScore as [Team, Team]));
+    await navigator.clipboard.writeText(formatShareText(gameScore));
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
 
   const battingTeam = gameScore.find((t) => t.currentBattingTeam) ?? gameScore[0];
   const bowlingTeam = gameScore.find((t) => t.currentBowlingTeam) ?? gameScore[1];
-  const result = determineResult(gameScore as [Team, Team]);
+  const result = determineResult(gameScore);
 
   const saveToCloud = async () => {
     setSaving(true);


### PR DESCRIPTION
## Summary

Fixes all 8 `noNonNullAssertion` biome lint warnings and several loose typing issues identified across the codebase.

### Changes

**New `lib/env.ts` helper**
- Adds `requireEnv(name)` — throws a clear `Error` if a required server-side environment variable is missing or empty, instead of silently asserting with `!`

**`lib/authOptions.ts`**
- Replaces `process.env.GOOGLE_CLIENT_ID!` and `process.env.GOOGLE_CLIENT_SECRET!` with `requireEnv()` calls
- Replaces `token.sub!` with `token.sub ?? ''` — `sub` is technically optional in JWT spec; the nullish coalescing is safer and still satisfies the `id: string` type requirement

**`lib/prisma.ts`**
- Replaces `process.env.DATABASE_URL!` with `requireEnv('DATABASE_URL')` — if the DB URL is missing the error message is now actionable

**`lib/stripe.ts`**
- Replaces `process.env.STRIPE_SECRET_KEY!` with `requireEnv('STRIPE_SECRET_KEY')`

**`pages/api/stripe/webhook.ts`**
- Replaces `process.env.STRIPE_WEBHOOK_SECRET!` with `requireEnv('STRIPE_WEBHOOK_SECRET')`
- Fixes `stripe-signature` header: `req.headers['stripe-signature']` is typed as `string | string[] | undefined`; the previous `as string` cast would silently pass `undefined` to `constructEvent`. Now we return 400 if the header is absent and pass the raw value (compatible with Stripe's `string | string[]` parameter type)

**`components/premium/UpgradeCTA.tsx`**
- `NEXT_PUBLIC_` env vars are baked in at build time and may be `undefined` in environments where they aren't set. Changes `subscribe` to accept `string | undefined` and return early if the price ID is absent, rather than asserting with `!`

**`components/scoring/scoring.tsx`**
- Early return when no batting/bowling team is found now returns `null` instead of `undefined` — React components must return `null` (not `undefined`) to signal "render nothing"

**`pages/summary.tsx`**
- Removes two redundant `as [Team, Team]` casts: `gameScore` is already typed as `GameScore = [Team, Team]`, so the assertions were unnecessary noise

### Why

All 8 biome `noNonNullAssertion` warnings now clear, and `yarn lint` exits cleanly. The deeper fixes (stripe-signature, scoring return, redundant casts) improve correctness and reduce silent runtime surprises.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8xTywVc4wb7861YQhDdE8)_