### PR TITLE
test: unit tests for gameSaveTitle, useMilestone, MilestoneToast, and SaveCard

### DIFF
--- a/components/milestone/MilestoneToast.spec.tsx
+++ b/components/milestone/MilestoneToast.spec.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import { MilestoneToast } from './MilestoneToast';
+
+describe('MilestoneToast', () => {
+  it('renders the message text with correct ARIA role and live-region attributes', () => {
+    render(<MilestoneToast message="WICKET!" accent="#b83320" />);
+    const toast = screen.getByRole('status');
+    expect(toast).toBeInTheDocument();
+    expect(screen.getByText('WICKET!')).toBeInTheDocument();
+    expect(toast).toHaveAttribute('aria-live', 'polite');
+    expect(toast).toHaveAttribute('aria-atomic', 'true');
+  });
+});

--- a/components/saves/SaveCard.spec.tsx
+++ b/components/saves/SaveCard.spec.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import SaveCard from './SaveCard';
+
+const baseProps = {
+  id: 'save-1',
+  title: 'England vs Australia — 15 Jan',
+  createdAt: new Date('2026-01-15T12:00:00.000Z'),
+  completed: false,
+};
+
+describe('SaveCard', () => {
+  it('renders the save title, formatted date, and status badge', () => {
+    render(<SaveCard {...baseProps} />);
+    expect(screen.getByText('England vs Australia — 15 Jan')).toBeInTheDocument();
+    expect(screen.getByText('In progress')).toBeInTheDocument();
+    // Date rendered via toLocaleDateString en-GB with year
+    expect(screen.getByText(/Jan 2026/)).toBeInTheDocument();
+  });
+
+  it('shows the season dropdown with all options when seasons and onSeasonChange are provided', () => {
+    const onSeasonChange = jest.fn();
+    const seasons = [
+      { id: 'season-1', name: 'Summer 2026' },
+      { id: 'season-2', name: 'Winter 2025' },
+    ];
+    render(<SaveCard {...baseProps} seasons={seasons} onSeasonChange={onSeasonChange} />);
+
+    const select = screen.getByLabelText('Assign to season');
+    expect(select).toBeInTheDocument();
+    expect(screen.getByText('No season')).toBeInTheDocument();
+    expect(screen.getByText('Summer 2026')).toBeInTheDocument();
+    expect(screen.getByText('Winter 2025')).toBeInTheDocument();
+  });
+
+  it('calls onSeasonChange with the save id and selected season id when a season is chosen', () => {
+    const onSeasonChange = jest.fn();
+    const seasons = [{ id: 'season-1', name: 'Summer 2026' }];
+    render(<SaveCard {...baseProps} seasons={seasons} onSeasonChange={onSeasonChange} />);
+
+    fireEvent.change(screen.getByLabelText('Assign to season'), { target: { value: 'season-1' } });
+    expect(onSeasonChange).toHaveBeenCalledWith('save-1', 'season-1');
+  });
+});

--- a/lib/gameSaveTitle.spec.ts
+++ b/lib/gameSaveTitle.spec.ts
@@ -1,0 +1,17 @@
+import { generateSaveTitle } from './gameSaveTitle';
+import type { GameScore } from '../context/GameContext';
+
+describe('generateSaveTitle', () => {
+  it('generates a title combining both team names with " vs " and a date', () => {
+    const score = [{ name: 'Team 1' }, { name: 'Team 2' }] as unknown as GameScore;
+    const title = generateSaveTitle(score);
+    // Format: "Team 1 vs Team 2 — DD Mon"
+    expect(title).toMatch(/^Team 1 vs Team 2 — \d{1,2} \w{3}$/);
+  });
+
+  it('reflects the exact names from both teams', () => {
+    const score = [{ name: 'Team 1' }, { name: 'Team 2' }] as unknown as GameScore;
+    const title = generateSaveTitle(score);
+    expect(title).toContain('Team 1 vs Team 2');
+  });
+});

--- a/utils/useMilestone.spec.tsx
+++ b/utils/useMilestone.spec.tsx
@@ -1,0 +1,112 @@
+import { renderHook } from '@testing-library/react';
+import { useMilestone } from './useMilestone';
+import type { GameScore } from '../context/GameContext';
+
+const makeGameScore = (strikerRuns: number, allActions: (string | null)[] = []): GameScore =>
+  [
+    {
+      players: [
+        {
+          index: 0,
+          name: 'Test Player',
+          runs: strikerRuns,
+          wicketsTaken: 0,
+          currentStriker: true,
+          currentNonStriker: false,
+          currentBowler: false,
+          onTheCrease: true,
+          status: 'Not out',
+          methodOfWicket: null,
+          allActions,
+          oversBowled: 0,
+          runsConceded: 0,
+        },
+      ],
+      name: 'Team 1',
+      index: 0,
+      totalRuns: strikerRuns,
+      totalWicketsConceded: 0,
+      totalWicketsTaken: 0,
+      overs: 0,
+      currentBattingTeam: true,
+      currentBowlingTeam: false,
+      finishedBatting: false,
+    },
+    {
+      players: [],
+      name: 'Team 2',
+      index: 1,
+      totalRuns: 0,
+      totalWicketsConceded: 0,
+      totalWicketsTaken: 0,
+      overs: 0,
+      currentBattingTeam: false,
+      currentBowlingTeam: true,
+      finishedBatting: false,
+    },
+  ] as GameScore;
+
+type HookProps = {
+  action: { runs: number; action: string | null };
+  score: GameScore;
+  over: number;
+};
+
+describe('useMilestone', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns null on the initial render', () => {
+    const { result } = renderHook(() =>
+      useMilestone({ runs: 0, action: null }, makeGameScore(0), 1)
+    );
+    expect(result.current).toBeNull();
+  });
+
+  it('fires a WICKET milestone when mostRecentAction has action "Wicket"', () => {
+    const initial: HookProps = { action: { runs: 0, action: null }, score: makeGameScore(0), over: 1 };
+    const { result, rerender } = renderHook(
+      ({ action, score, over }: HookProps) => useMilestone(action, score, over),
+      { initialProps: initial }
+    );
+    expect(result.current).toBeNull();
+
+    rerender({ action: { runs: 0, action: 'Wicket' }, score: makeGameScore(0), over: 1 });
+    expect(result.current?.message).toBe('WICKET!');
+    expect(result.current?.accent).toBe('#b83320');
+  });
+
+  it('fires a FIFTY milestone when striker crosses 50 runs', () => {
+    const { result, rerender } = renderHook(
+      ({ action, score, over }: HookProps) => useMilestone(action, score, over),
+      // Initial: striker has 47 runs; init effect stores prevStrikerRuns = 47
+      { initialProps: { action: { runs: 1, action: null }, score: makeGameScore(47), over: 1 } }
+    );
+    expect(result.current).toBeNull();
+
+    // Rerender: striker now has 53 runs — crossed 50
+    rerender({ action: { runs: 6, action: null }, score: makeGameScore(53), over: 1 });
+    expect(result.current?.message).toContain('FIFTY!');
+    expect(result.current?.message).toContain('Test Player');
+  });
+
+  it('fires an end-of-over milestone when currentOver increments', () => {
+    // Use a stable object reference for mostRecentAction so the ball-by-ball effect
+    // does not re-trigger — only the currentOver effect fires.
+    const stableAction = { runs: 0, action: null };
+    const { result, rerender } = renderHook(
+      ({ action, score, over }: HookProps) => useMilestone(action, score, over),
+      { initialProps: { action: stableAction, score: makeGameScore(0), over: 1 } }
+    );
+    expect(result.current).toBeNull();
+
+    rerender({ action: stableAction, score: makeGameScore(0), over: 2 });
+    expect(result.current?.message).toBe('End of over 1');
+    expect(result.current?.accent).toBe('#2d7a4f');
+  });
+});


### PR DESCRIPTION
## Summary

Four previously-untested areas now have unit test coverage (10 new tests across 4 files):

- **`lib/gameSaveTitle.spec.ts`** — verifies the generated save title contains both team names in `"A vs B — DD Mon"` format
- **`utils/useMilestone.spec.tsx`** — verifies the hook returns `null` initially, fires `WICKET!`, `FIFTY!`, and `End of over N` milestones at the correct times using `renderHook` + fake timers
- **`components/milestone/MilestoneToast.spec.tsx`** — verifies the toast renders its message with the correct `role="status"`, `aria-live="polite"`, and `aria-atomic="true"` attributes
- **`components/saves/SaveCard.spec.tsx`** — verifies title/date/badge rendering, season dropdown population when `seasons` prop is provided, and that `onSeasonChange` is called with the correct save id and season id

## Why these areas

These were the highest-value untested files: `useMilestone` contains the milestone detection logic that drives in-game feedback; `SaveCard` is used on the Dashboard for every saved game and has interactive season-assignment; `MilestoneToast` carries accessibility-critical ARIA attributes; and `gameSaveTitle` is a pure utility used when saving games to the cloud.

All 90 tests pass. `yarn lint` (`tsc --noEmit && biome lint .`) exits cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_011dgeTK2mxhRqk1FNzqSWe9)_