### PR TITLE
perf: migrate dashboard to getServerSideProps; fix inline style object churn

### DIFF
--- a/components/auth/UserMenu.tsx
+++ b/components/auth/UserMenu.tsx
@@ -38,7 +38,7 @@ export default function UserMenu() {
     <Wrapper ref={ref}>
       <Avatar onClick={() => setIsOpen(!isOpen)} aria-label="User menu" aria-expanded={isOpen} aria-haspopup="true">
         {session.user?.image ? (
-          <Image src={session.user.image} alt={session.user.name ?? ''} width={32} height={32} style={{ objectFit: 'cover' }} />
+          <Image src={session.user.image} alt={session.user.name ?? ''} width={32} height={32} />
         ) : (
           initials
         )}

--- a/components/saves/SaveCard.tsx
+++ b/components/saves/SaveCard.tsx
@@ -1,10 +1,13 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
-import type { GameSave } from '@prisma/client';
 
 type Season = { id: string; name: string };
 
-type SaveCardProps = Pick<GameSave, 'id' | 'title' | 'createdAt' | 'completed'> & {
+type SaveCardProps = {
+  id: string;
+  title: string | null;
+  createdAt: Date | string;
+  completed: boolean;
   seasonId?: string | null;
   seasons?: Season[];
   onSeasonChange?: (saveId: string, seasonId: string | null) => void;

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,57 +1,49 @@
 import styled from "@emotion/styled";
+import type { GetServerSideProps } from "next";
 import { useSession } from "next-auth/react";
-import { useEffect, useState } from "react";
+import { getServerSession } from "next-auth/next";
+import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { useRouter } from "next/router";
 import Layout from "../components/layout/layout";
 import SaveCard from "../components/saves/SaveCard";
 import UpgradeCTA from "../components/premium/UpgradeCTA";
-import { useAccount } from "../context/AccountContext";
 import { generateSaveTitle } from "../lib/gameSaveTitle";
 import { useGameScore } from "../context/GameScoreContext";
-import type { GameSave } from "@prisma/client";
+import { authOptions } from "../lib/authOptions";
+import { getUserTier } from "../lib/subscription";
+import { prisma } from "../lib/prisma";
 
-type SaveSummary = Pick<
-  GameSave,
-  "id" | "title" | "createdAt" | "completed" | "seasonId"
->;
+type SaveSummary = {
+  id: string;
+  title: string | null;
+  createdAt: string;
+  completed: boolean;
+  seasonId: string | null;
+};
 
 type SeasonSummary = { id: string; name: string };
 
-export default function DashboardPage() {
+type PageProps = {
+  initialSaves: SaveSummary[];
+  initialSeasons: SeasonSummary[];
+  tier: "free" | "premium";
+};
+
+export default function DashboardPage({ initialSaves, initialSeasons, tier }: PageProps) {
   const { data: session } = useSession();
-  const { tier, isLoading: accountLoading } = useAccount();
   const { gameScore } = useGameScore();
   const router = useRouter();
-  const [saves, setSaves] = useState<SaveSummary[]>([]);
-  const [seasons, setSeasons] = useState<SeasonSummary[]>([]);
-  const [savesLoading, setSavesLoading] = useState(true);
+  const [saves, setSaves] = useState<SaveSummary[]>(initialSaves);
+  const [seasons] = useState<SeasonSummary[]>(initialSeasons);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
-  const [savesError, setSavesError] = useState(false);
   const [checkoutSuccess, setCheckoutSuccess] = useState(false);
 
   const hasLocalGame =
     typeof window !== "undefined" && Boolean(localStorage.getItem("gameData"));
-
-  useEffect(() => {
-    if (!session) return;
-    fetch("/api/saves")
-      .then((r) => { if (!r.ok) throw new Error('fetch failed'); return r.json(); })
-      .then((data) => setSaves(data))
-      .catch(() => setSavesError(true))
-      .finally(() => setSavesLoading(false));
-  }, [session]);
-
-  useEffect(() => {
-    if (!session || tier !== "premium") return;
-    fetch("/api/seasons")
-      .then((r) => { if (!r.ok) throw new Error('fetch failed'); return r.json(); })
-      .then((data: SeasonSummary[]) => setSeasons(data))
-      .catch(() => {});
-  }, [session, tier]);
 
   useEffect(() => {
     if (!session || router.query.checkout !== "success") return;
@@ -68,7 +60,7 @@ export default function DashboardPage() {
     }
   }, []);
 
-  const assignSeason = async (saveId: string, seasonId: string | null) => {
+  const assignSeason = useCallback(async (saveId: string, seasonId: string | null) => {
     const res = await fetch(`/api/saves/${saveId}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
@@ -79,7 +71,7 @@ export default function DashboardPage() {
         prev.map((s) => (s.id === saveId ? { ...s, seasonId } : s))
       );
     }
-  };
+  }, []);
 
   const saveToCloud = async () => {
     setSaving(true);
@@ -130,22 +122,6 @@ export default function DashboardPage() {
     }
   };
 
-  if (!session) {
-    return (
-      <Layout
-        title="Dashboard"
-        description="View and manage your cloud saves and cricket seasons."
-      >
-        <PageWrapper>
-          <p>
-            Please <Link href="/auth/signin">sign in</Link> to view your
-            dashboard.
-          </p>
-        </PageWrapper>
-      </Layout>
-    );
-  }
-
   return (
     <Layout
       title="Dashboard"
@@ -160,17 +136,16 @@ export default function DashboardPage() {
 
         <AccountSection>
           <Avatar>
-            {session.user?.image ? (
+            {session?.user?.image ? (
               <Image
                 src={session.user.image}
                 alt={session.user.name ?? ""}
                 width={56}
                 height={56}
-                style={{ objectFit: "cover" }}
               />
             ) : (
               <AvatarInitials>
-                {session.user?.name
+                {session?.user?.name
                   ?.split(" ")
                   .map((n) => n[0])
                   .join("")
@@ -180,14 +155,12 @@ export default function DashboardPage() {
             )}
           </Avatar>
           <AccountInfo>
-            <AccountName>{session.user?.name}</AccountName>
-            <AccountEmail>{session.user?.email}</AccountEmail>
+            <AccountName>{session?.user?.name}</AccountName>
+            <AccountEmail>{session?.user?.email}</AccountEmail>
           </AccountInfo>
-          {!accountLoading && (
-            <TierBadge premium={tier === "premium"}>
-              {tier === "premium" ? "Premium" : "Free"}
-            </TierBadge>
-          )}
+          <TierBadge premium={tier === "premium"}>
+            {tier === "premium" ? "Premium" : "Free"}
+          </TierBadge>
         </AccountSection>
 
         <SectionHeader>
@@ -210,11 +183,7 @@ export default function DashboardPage() {
         )}
         {saveSuccess && <SuccessMessage role="status">Game saved!</SuccessMessage>}
 
-        {savesLoading ? (
-          <EmptyState>Loading saves…</EmptyState>
-        ) : savesError ? (
-          <ErrorMessage role="alert">Could not load saves. Please refresh.</ErrorMessage>
-        ) : saves.length === 0 ? (
+        {saves.length === 0 ? (
           <EmptyState>
             No cloud saves yet. Finish a game and save it from the Summary page.
           </EmptyState>
@@ -250,6 +219,41 @@ export default function DashboardPage() {
     </Layout>
   );
 }
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+  const session = await getServerSession(context.req, context.res, authOptions);
+  if (!session) {
+    return { redirect: { destination: "/auth/signin", permanent: false } };
+  }
+
+  const userId = session.user.id;
+  const tier = await getUserTier(userId);
+
+  const rawSaves = await prisma.gameSave.findMany({
+    where: { userId },
+    select: { id: true, title: true, createdAt: true, completed: true, seasonId: true },
+    orderBy: { createdAt: "desc" },
+  });
+
+  const initialSaves: SaveSummary[] = rawSaves.map((s) => ({
+    id: s.id,
+    title: s.title,
+    createdAt: s.createdAt.toISOString(),
+    completed: s.completed,
+    seasonId: s.seasonId,
+  }));
+
+  let initialSeasons: SeasonSummary[] = [];
+  if (tier === "premium") {
+    initialSeasons = await prisma.season.findMany({
+      where: { userId },
+      select: { id: true, name: true },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  return { props: { initialSaves, initialSeasons, tier } };
+};
 
 const PageWrapper = styled.main`
   width: 100%;

--- a/pages/match.tsx
+++ b/pages/match.tsx
@@ -12,6 +12,7 @@ import { useOvers } from "../context/OversContext";
 import { useMilestone } from "../utils/useMilestone";
 
 const TOTAL_OVERS = 20;
+const CONTAIN_STYLE = { objectFit: 'contain' as const };
 const BALLS_PER_OVER = 6;
 const TOTAL_BALLS = TOTAL_OVERS * BALLS_PER_OVER;
 const MAX_RUN_RATE_DISPLAY = 12;
@@ -216,7 +217,7 @@ const MatchPage: React.FC = () => {
           </TeamSide>
           <MatchCentre>
             <BallIconWrapper>
-              <Image src="/icons/png/006-cricket-1.png" alt="cricket ball" fill style={{ objectFit: "contain" }} />
+              <Image src="/icons/png/006-cricket-1.png" alt="cricket ball" fill style={CONTAIN_STYLE} />
             </BallIconWrapper>
             <Vs>vs</Vs>
             <Format>T20 — 20 Overs</Format>

--- a/pages/summary.tsx
+++ b/pages/summary.tsx
@@ -11,6 +11,7 @@ import { generateSaveTitle } from '../lib/gameSaveTitle';
 import { formatShareText } from '../utils/formatShareText';
 
 const TEAM_COLORS = ['#b83320', '#2d7a4f'] as const;
+const CONTAIN_STYLE = { objectFit: 'contain' as const };
 
 function getInitials(name: string): string {
   return name
@@ -131,7 +132,7 @@ const SummaryPage: React.FC = () => {
           </TeamSide>
 
           <MatchCentre>
-            <Image src="/icons/png/006-cricket-1.png" alt="cricket ball" width={56} height={56} style={{ objectFit: "contain" }} />
+            <Image src="/icons/png/006-cricket-1.png" alt="cricket ball" width={56} height={56} style={CONTAIN_STYLE} />
             <Vs>vs</Vs>
             <Format>T20 · 20 Overs</Format>
           </MatchCentre>


### PR DESCRIPTION
## Summary

- **Dashboard data fetching moved to `getServerSideProps`** — the biggest change. The dashboard previously fetched saves and seasons on the client via two `useEffect` hooks, causing a "Loading saves…" flash on every visit. Both fetches now happen server-side before the page is sent to the browser, so saves render immediately. Unauthenticated users are redirected to sign-in server-side rather than seeing a flash of a sign-in message. The `useAccount` import is removed; `tier` comes in as a prop, so the tier badge now renders immediately too (no `accountLoading` guard needed).

- **`assignSeason` wrapped in `useCallback`** — this function was recreated on every render and passed as a prop to every `SaveCard` in the list. Wrapping it in `useCallback` stabilises the reference.

- **Redundant `style={{ objectFit: '...' }}` props removed** from `UserMenu.tsx` and `dashboard.tsx` — both `Avatar` styled components already apply `img { object-fit: cover }` via CSS, making the inline prop a no-op that still allocates a new object on every render.

- **Inline style object literals extracted to module-level constants** in `match.tsx` and `summary.tsx` — `style={{ objectFit: "contain" }}` was written inline on `next/image` calls, allocating a new object on every render. Each file now has a `CONTAIN_STYLE` constant defined once at module scope.

- **`SaveCard` `createdAt` type broadened to `Date | string`** — Prisma returns `Date` objects, but `getServerSideProps` serialises them to ISO strings. The component already calls `new Date(createdAt)` which handles both forms at runtime; the type now reflects that.

## Changes

| File | Change |
|---|---|
| `pages/dashboard.tsx` | Add `getServerSideProps`; remove client-side save/season fetches; remove `useAccount`; wrap `assignSeason` in `useCallback`; remove redundant `style` prop |
| `components/saves/SaveCard.tsx` | Broaden `createdAt` type to `Date \| string` |
| `components/auth/UserMenu.tsx` | Remove redundant `style={{ objectFit: 'cover' }}` prop |
| `pages/match.tsx` | Extract `objectFit: 'contain'` to module-level `CONTAIN_STYLE` constant |
| `pages/summary.tsx` | Extract `objectFit: 'contain'` to module-level `CONTAIN_STYLE` constant |

## Test plan

- [ ] All 116 existing tests pass (`yarn test`)
- [ ] `yarn lint` exits 0
- [ ] Dashboard page loads without "Loading saves…" flash when authenticated
- [ ] Unauthenticated users visiting `/dashboard` are redirected to `/auth/signin`
- [ ] Premium users see their seasons dropdown on each save card
- [ ] Free users do not see the seasons dropdown
- [ ] The tier badge renders immediately without a loading delay

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQoSsQb3KbPS6E5AaBThgT)_