### PR TITLE
fix: resolve high-severity yarn audit finding (hono CORS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
     "prisma": "^7.8.0",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.0"
+  },
+  "resolutions": {
+    "hono": "^4.12.25"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3442,10 +3442,10 @@ hoist-non-react-statics@^3.3.1:
   dependencies:
     react-is "^16.7.0"
 
-hono@^4.12.8:
-  version "4.12.24"
-  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.24.tgz#193c8d65ab463747fdde9d05c0d7a67859270da7"
-  integrity sha512-I36D1s+HgQc55KbhEr4iybfxv/9o1zdpw+XEM6dJa91LqQD0HCoSGdxpRJCZE+aavs87j4V3Ls2OJzq8C/U4iw==
+hono@^4.12.25, hono@^4.12.8:
+  version "4.12.30"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.30.tgz#4d57b051c66617b003b7ba318910cb5b79c4c7ac"
+  integrity sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==
 
 html-encoding-sniffer@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Summary
- `yarn audit --level high` flagged one high-severity advisory: [GHSA-88fw-hqm2-52qc](https://github.com/advisories/GHSA-88fw-hqm2-52qc) (CVE-2026-54290) in `hono`, which reflects any `Origin` when CORS `credentials: true` is set without an explicit origin.
- `hono` is pulled in transitively via `prisma > @prisma/dev`, used only by Prisma's dev tooling (not our runtime code). Prisma hasn't shipped a release with the fix yet, so this pins `hono` to `^4.12.25` (patched) via a `resolutions` entry in `package.json`.
- Moderate-severity findings (13) are left untouched, as requested — only the high was in scope.

## Test plan
- [x] `yarn audit --level high` now reports 0 high severity issues
- [x] `yarn jest` — 116/116 tests pass