### PR TITLE
feat: pre-match team and player name setup flow

### DIFF
--- a/__tests__/pages/index.spec.tsx
+++ b/__tests__/pages/index.spec.tsx
@@ -52,19 +52,13 @@ describe('Index page', () => {
   });
 
   describe('newGame', () => {
-    it('clears localStorage, calls setGameScore with two teams, and navigates to /match', () => {
+    it('clears localStorage and navigates to /setup', () => {
       localStorage.setItem('gameData', JSON.stringify({ some: 'data' }));
       renderIndex();
       fireEvent.click(screen.getByRole('button', { name: /start new match/i }));
       expect(localStorage.getItem('gameData')).toBeNull();
-      expect(setGameScore).toHaveBeenCalledTimes(1);
-      const [teams] = setGameScore.mock.calls[0] as [GameScore];
-      expect(teams).toHaveLength(2);
-      expect(teams[0].name).toBe('Team 1');
-      expect(teams[1].name).toBe('Team 2');
-      expect(teams[0].currentBattingTeam).toBe(true);
-      expect(teams[1].currentBowlingTeam).toBe(true);
-      expect(mockPush).toHaveBeenCalledWith('/match');
+      expect(setGameScore).not.toHaveBeenCalled();
+      expect(mockPush).toHaveBeenCalledWith('/setup');
     });
   });
 

--- a/__tests__/pages/setup.spec.tsx
+++ b/__tests__/pages/setup.spec.tsx
@@ -76,13 +76,47 @@ describe('Setup page', () => {
     expect(teams[0].players[1].name).toBe('Player 2');
   });
 
-  it('quick fill populates numbered defaults into the visible inputs', () => {
-    renderSetup();
-    fireEvent.click(screen.getByRole('button', { name: /quick fill/i }));
+  describe('bulk paste', () => {
+    const paste = (element: HTMLElement, text: string) =>
+      fireEvent.paste(element, { clipboardData: { getData: () => text } });
 
-    expect(screen.getByLabelText('Team 1 name')).toHaveValue('Team 1');
-    expect(screen.getByLabelText('Team 2 name')).toHaveValue('Team 2');
-    expect(screen.getByLabelText('Team 1 player 1 name')).toHaveValue('Player 1');
-    expect(screen.getByLabelText('Team 2 player 11 name')).toHaveValue('Player 11');
+    it('pasting a comma-separated list into a player field distributes it across subsequent players', () => {
+      renderSetup();
+      paste(screen.getByLabelText('Team 1 player 1 name'), 'Alice, Bob, Carol');
+      fireEvent.click(screen.getByRole('button', { name: /start match/i }));
+
+      const [teams] = setGameScore.mock.calls[0] as [GameScore];
+      expect(teams[0].players[0].name).toBe('Alice');
+      expect(teams[0].players[1].name).toBe('Bob');
+      expect(teams[0].players[2].name).toBe('Carol');
+      expect(teams[0].players[3].name).toBe('Player 4');
+    });
+
+    it('pasting a newline-separated list starting mid-roster fills from that slot onward', () => {
+      renderSetup();
+      paste(screen.getByLabelText('Team 2 player 10 name'), 'Player Ten\nPlayer Eleven\nOverflow');
+
+      expect(screen.getByLabelText('Team 2 player 10 name')).toHaveValue('Player Ten');
+      expect(screen.getByLabelText('Team 2 player 11 name')).toHaveValue('Player Eleven');
+    });
+
+    it('a single-value paste is left to the default paste behaviour', () => {
+      renderSetup();
+      paste(screen.getByLabelText('Team 1 player 1 name'), 'Alice');
+
+      expect(screen.getByLabelText('Team 1 player 1 name')).toHaveValue('');
+    });
+
+    it('pasting a roster into the team name field sets the team name and all player names', () => {
+      renderSetup();
+      paste(screen.getByLabelText('Team 1 name'), 'Runswick CC, Alice, Bob');
+      fireEvent.click(screen.getByRole('button', { name: /start match/i }));
+
+      const [teams] = setGameScore.mock.calls[0] as [GameScore];
+      expect(teams[0].name).toBe('Runswick CC');
+      expect(teams[0].players[0].name).toBe('Alice');
+      expect(teams[0].players[1].name).toBe('Bob');
+      expect(teams[0].players[2].name).toBe('Player 3');
+    });
   });
 });

--- a/__tests__/pages/setup.spec.tsx
+++ b/__tests__/pages/setup.spec.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { GameScoreContext } from '../../context/GameScoreContext';
+import type { GameScore, GameScoreContextType } from '../../context/GameContext';
+import SetupPage from '../../pages/setup';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+const mockPush = jest.fn();
+
+const setGameScore = jest.fn();
+
+const contextValue: GameScoreContextType = {
+  gameScore: [] as unknown as GameScore,
+  setGameScore,
+  setBattingPlayerScore: jest.fn(),
+  setBowlingPlayerScore: jest.fn(),
+  swapBatsmen: jest.fn(),
+  setCurrentBowler: jest.fn(),
+  undo: jest.fn(),
+  canUndo: false,
+};
+
+const renderSetup = () =>
+  render(
+    <GameScoreContext.Provider value={contextValue}>
+      <SetupPage />
+    </GameScoreContext.Provider>
+  );
+
+describe('Setup page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders team name and player name inputs for both teams', () => {
+    renderSetup();
+    expect(screen.getByRole('heading', { name: /match setup/i })).toBeInTheDocument();
+    expect(screen.getByLabelText('Team 1 name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Team 2 name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Team 1 player 1 name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Team 1 player 11 name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Team 2 player 1 name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Team 2 player 11 name')).toBeInTheDocument();
+  });
+
+  it('starting a match with blank fields falls back to default names', () => {
+    renderSetup();
+    fireEvent.click(screen.getByRole('button', { name: /start match/i }));
+
+    expect(setGameScore).toHaveBeenCalledTimes(1);
+    const [teams] = setGameScore.mock.calls[0] as [GameScore];
+    expect(teams[0].name).toBe('Team 1');
+    expect(teams[1].name).toBe('Team 2');
+    expect(teams[0].players[0].name).toBe('Player 1');
+    expect(teams[1].players[10].name).toBe('Player 11');
+    expect(mockPush).toHaveBeenCalledWith('/match');
+  });
+
+  it('starting a match with entered names uses them', () => {
+    renderSetup();
+    fireEvent.change(screen.getByLabelText('Team 1 name'), { target: { value: 'Runswick CC' } });
+    fireEvent.change(screen.getByLabelText('Team 1 player 1 name'), {
+      target: { value: 'Alice' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /start match/i }));
+
+    const [teams] = setGameScore.mock.calls[0] as [GameScore];
+    expect(teams[0].name).toBe('Runswick CC');
+    expect(teams[0].players[0].name).toBe('Alice');
+    expect(teams[0].players[1].name).toBe('Player 2');
+  });
+
+  it('quick fill populates numbered defaults into the visible inputs', () => {
+    renderSetup();
+    fireEvent.click(screen.getByRole('button', { name: /quick fill/i }));
+
+    expect(screen.getByLabelText('Team 1 name')).toHaveValue('Team 1');
+    expect(screen.getByLabelText('Team 2 name')).toHaveValue('Team 2');
+    expect(screen.getByLabelText('Team 1 player 1 name')).toHaveValue('Player 1');
+    expect(screen.getByLabelText('Team 2 player 11 name')).toHaveValue('Player 11');
+  });
+});

--- a/components/core/players.tsx
+++ b/components/core/players.tsx
@@ -1,10 +1,12 @@
 import type { TeamPlayer } from '../../context/GameContext';
 
-const defaultPlayers = (): TeamPlayer[] => {
+const defaultPlayers = (names?: string[]): TeamPlayer[] => {
+  const nameAt = (i: number) => names?.[i]?.trim() || `Player ${i + 1}`;
+
   return [
     {
       index: 0,
-      name: 'Player 1',
+      name: nameAt(0),
       runs: 0,
       wicketsTaken: 0,
       currentStriker: true,
@@ -19,7 +21,7 @@ const defaultPlayers = (): TeamPlayer[] => {
     },
     {
       index: 1,
-      name: 'Player 2',
+      name: nameAt(1),
       runs: 0,
       wicketsTaken: 0,
       currentStriker: false,
@@ -34,7 +36,7 @@ const defaultPlayers = (): TeamPlayer[] => {
     },
     {
       index: 2,
-      name: 'Player 3',
+      name: nameAt(2),
       runs: 0,
       wicketsTaken: 0,
       currentStriker: false,
@@ -49,7 +51,7 @@ const defaultPlayers = (): TeamPlayer[] => {
     },
     {
       index: 3,
-      name: 'Player 4',
+      name: nameAt(3),
       runs: 0,
       wicketsTaken: 0,
       currentStriker: false,
@@ -64,7 +66,7 @@ const defaultPlayers = (): TeamPlayer[] => {
     },
     {
       index: 4,
-      name: 'Player 5',
+      name: nameAt(4),
       runs: 0,
       wicketsTaken: 0,
       currentStriker: false,
@@ -79,7 +81,7 @@ const defaultPlayers = (): TeamPlayer[] => {
     },
     {
       index: 5,
-      name: 'Player 6',
+      name: nameAt(5),
       runs: 0,
       wicketsTaken: 0,
       currentStriker: false,
@@ -94,7 +96,7 @@ const defaultPlayers = (): TeamPlayer[] => {
     },
     {
       index: 6,
-      name: 'Player 7',
+      name: nameAt(6),
       runs: 0,
       wicketsTaken: 0,
       currentStriker: false,
@@ -109,7 +111,7 @@ const defaultPlayers = (): TeamPlayer[] => {
     },
     {
       index: 7,
-      name: 'Player 8',
+      name: nameAt(7),
       runs: 0,
       wicketsTaken: 0,
       currentStriker: false,
@@ -124,7 +126,7 @@ const defaultPlayers = (): TeamPlayer[] => {
     },
     {
       index: 8,
-      name: 'Player 9',
+      name: nameAt(8),
       runs: 0,
       wicketsTaken: 0,
       currentStriker: false,
@@ -139,7 +141,7 @@ const defaultPlayers = (): TeamPlayer[] => {
     },
     {
       index: 9,
-      name: 'Player 10',
+      name: nameAt(9),
       runs: 0,
       wicketsTaken: 0,
       currentStriker: false,
@@ -154,7 +156,7 @@ const defaultPlayers = (): TeamPlayer[] => {
     },
     {
       index: 10,
-      name: 'Player 11',
+      name: nameAt(10),
       runs: 0,
       wicketsTaken: 0,
       currentStriker: false,

--- a/context/GameContext.tsx
+++ b/context/GameContext.tsx
@@ -22,7 +22,7 @@ export type TeamPlayer = {
 
 export type Team = {
   players: TeamPlayer[];
-  name: 'Team 1' | 'Team 2';
+  name: string;
   index: 0 | 1;
   totalRuns: number;
   totalWicketsConceded: number;
@@ -107,10 +107,15 @@ type GameAction =
   | { type: 'RESET_OVERS' }
   | { type: 'SET_MOST_RECENT_ACTION'; payload: { runs: number; action: string | null } };
 
-const makeInitialTeams = (): GameScore => [
+export type TeamSetup = {
+  name?: string;
+  playerNames?: string[];
+};
+
+export const makeInitialTeams = (team1?: TeamSetup, team2?: TeamSetup): GameScore => [
   {
-    players: defaultPlayers(),
-    name: 'Team 1',
+    players: defaultPlayers(team1?.playerNames),
+    name: team1?.name?.trim() || 'Team 1',
     index: 0,
     totalRuns: 0,
     totalWicketsConceded: 0,
@@ -121,8 +126,8 @@ const makeInitialTeams = (): GameScore => [
     finishedBatting: false
   },
   {
-    players: defaultPlayers(),
-    name: 'Team 2',
+    players: defaultPlayers(team2?.playerNames),
+    name: team2?.name?.trim() || 'Team 2',
     index: 1,
     totalRuns: 0,
     totalWicketsConceded: 0,

--- a/context/GameScoreContext.tsx
+++ b/context/GameScoreContext.tsx
@@ -1,2 +1,2 @@
-export type { GameScore, GameScoreContextType } from './GameContext';
-export { GameProvider as GameScoreProvider, GameScoreContext, useGameScore } from './GameContext';
+export type { GameScore, GameScoreContextType, TeamSetup } from './GameContext';
+export { GameProvider as GameScoreProvider, GameScoreContext, useGameScore, makeInitialTeams } from './GameContext';

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,7 +5,6 @@ import { useState } from "react";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
 import { PrimaryButton, SecondaryButton } from "../components/core/buttons";
-import defaultPlayers from "../components/core/players";
 import Layout from "../components/layout/layout";
 import PitchDiagram from "../components/pitch/pitch-diagram";
 import { useGameScore } from "../context/GameScoreContext";
@@ -50,33 +49,7 @@ const Index: React.FC = () => {
   const newGame = () => {
     localStorage.removeItem("gameData");
     localStorage.removeItem("cloudSaveId");
-    setGameScore([
-      {
-        players: defaultPlayers(),
-        name: "Team 1",
-        index: 0,
-        totalRuns: 0,
-        totalWicketsConceded: 0,
-        totalWicketsTaken: 0,
-        overs: 0,
-        currentBattingTeam: true,
-        currentBowlingTeam: false,
-        finishedBatting: false,
-      },
-      {
-        players: defaultPlayers(),
-        name: "Team 2",
-        index: 1,
-        totalRuns: 0,
-        totalWicketsConceded: 0,
-        totalWicketsTaken: 0,
-        overs: 0,
-        currentBattingTeam: false,
-        currentBowlingTeam: true,
-        finishedBatting: false,
-      },
-    ]);
-    router.push("/match");
+    router.push("/setup");
   };
 
   return (

--- a/pages/setup.tsx
+++ b/pages/setup.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { useRouter } from "next/router";
 import type React from "react";
 import { useState } from "react";
-import { PrimaryButton, SecondaryButton } from "../components/core/buttons";
+import { PrimaryButton } from "../components/core/buttons";
 import Layout from "../components/layout/layout";
 import { makeInitialTeams, useGameScore } from "../context/GameScoreContext";
 
@@ -19,10 +19,13 @@ const emptyTeam = (): TeamFormState => ({
   playerNames: Array(PLAYERS_PER_TEAM).fill(""),
 });
 
-const quickFilledTeam = (teamNumber: 1 | 2): TeamFormState => ({
-  name: `Team ${teamNumber}`,
-  playerNames: Array.from({ length: PLAYERS_PER_TEAM }, (_, i) => `Player ${i + 1}`),
-});
+const NAME_LIST_SEPARATOR = /[,;\n\r\t]+/;
+
+const parseNameList = (text: string): string[] =>
+  text
+    .split(NAME_LIST_SEPARATOR)
+    .map((name) => name.trim())
+    .filter(Boolean);
 
 const SetupPage: React.FC = () => {
   const router = useRouter();
@@ -50,8 +53,42 @@ const SetupPage: React.FC = () => {
     });
   };
 
-  const quickFill = () => {
-    setTeams([quickFilledTeam(1), quickFilledTeam(2)]);
+  const pasteTeamRoster = (teamIndex: 0 | 1, e: React.ClipboardEvent<HTMLInputElement>) => {
+    const names = parseNameList(e.clipboardData.getData("text"));
+    if (names.length <= 1) return;
+
+    e.preventDefault();
+    const [name, ...playerNames] = names;
+    setTeams((prev) => {
+      const next = [...prev] as [TeamFormState, TeamFormState];
+      const nextPlayerNames = [...next[teamIndex].playerNames];
+      playerNames.forEach((playerName, index) => {
+        if (index < PLAYERS_PER_TEAM) nextPlayerNames[index] = playerName;
+      });
+      next[teamIndex] = { name, playerNames: nextPlayerNames };
+      return next;
+    });
+  };
+
+  const pastePlayerNames = (
+    teamIndex: 0 | 1,
+    playerIndex: number,
+    e: React.ClipboardEvent<HTMLInputElement>
+  ) => {
+    const names = parseNameList(e.clipboardData.getData("text"));
+    if (names.length <= 1) return;
+
+    e.preventDefault();
+    setTeams((prev) => {
+      const next = [...prev] as [TeamFormState, TeamFormState];
+      const playerNames = [...next[teamIndex].playerNames];
+      names.forEach((name, offset) => {
+        const index = playerIndex + offset;
+        if (index < PLAYERS_PER_TEAM) playerNames[index] = name;
+      });
+      next[teamIndex] = { ...next[teamIndex], playerNames };
+      return next;
+    });
   };
 
   const startMatch = () => {
@@ -72,9 +109,6 @@ const SetupPage: React.FC = () => {
       <PageWrapper>
         <PageHeader>
           <PageTitle>Match setup</PageTitle>
-          <SecondaryButton type="button" onClick={quickFill}>
-            Quick fill
-          </SecondaryButton>
         </PageHeader>
 
         <TeamsGrid>
@@ -87,6 +121,7 @@ const SetupPage: React.FC = () => {
                 value={team.name}
                 color={TEAM_COLORS[teamIndex]}
                 onChange={(e) => updateTeamName(teamIndex as 0 | 1, e.target.value)}
+                onPaste={(e) => pasteTeamRoster(teamIndex as 0 | 1, e)}
               />
               <PlayerList>
                 {team.playerNames.map((playerName, playerIndex) => (
@@ -100,10 +135,12 @@ const SetupPage: React.FC = () => {
                       onChange={(e) =>
                         updatePlayerName(teamIndex as 0 | 1, playerIndex, e.target.value)
                       }
+                      onPaste={(e) => pastePlayerNames(teamIndex as 0 | 1, playerIndex, e)}
                     />
                   </PlayerRow>
                 ))}
               </PlayerList>
+              <PasteHint>Tip: paste a comma or line-separated list to fill several names at once</PasteHint>
             </TeamPanel>
           ))}
         </TeamsGrid>
@@ -224,4 +261,11 @@ const ButtonsContainer = styled.div`
   display: flex;
   justify-content: center;
   margin-top: 2rem;
+`;
+
+const PasteHint = styled.p`
+  font-family: "Inter", sans-serif;
+  font-size: 0.75rem;
+  color: #767676;
+  margin: 0.75rem 0 0;
 `;

--- a/pages/setup.tsx
+++ b/pages/setup.tsx
@@ -1,0 +1,227 @@
+import styled from "@emotion/styled";
+import { useRouter } from "next/router";
+import type React from "react";
+import { useState } from "react";
+import { PrimaryButton, SecondaryButton } from "../components/core/buttons";
+import Layout from "../components/layout/layout";
+import { makeInitialTeams, useGameScore } from "../context/GameScoreContext";
+
+const TEAM_COLORS = ["#b83320", "#2d7a4f"] as const;
+const PLAYERS_PER_TEAM = 11;
+
+type TeamFormState = {
+  name: string;
+  playerNames: string[];
+};
+
+const emptyTeam = (): TeamFormState => ({
+  name: "",
+  playerNames: Array(PLAYERS_PER_TEAM).fill(""),
+});
+
+const quickFilledTeam = (teamNumber: 1 | 2): TeamFormState => ({
+  name: `Team ${teamNumber}`,
+  playerNames: Array.from({ length: PLAYERS_PER_TEAM }, (_, i) => `Player ${i + 1}`),
+});
+
+const SetupPage: React.FC = () => {
+  const router = useRouter();
+  const { setGameScore } = useGameScore();
+  const [teams, setTeams] = useState<[TeamFormState, TeamFormState]>([
+    emptyTeam(),
+    emptyTeam(),
+  ]);
+
+  const updateTeamName = (teamIndex: 0 | 1, name: string) => {
+    setTeams((prev) => {
+      const next = [...prev] as [TeamFormState, TeamFormState];
+      next[teamIndex] = { ...next[teamIndex], name };
+      return next;
+    });
+  };
+
+  const updatePlayerName = (teamIndex: 0 | 1, playerIndex: number, name: string) => {
+    setTeams((prev) => {
+      const next = [...prev] as [TeamFormState, TeamFormState];
+      const playerNames = [...next[teamIndex].playerNames];
+      playerNames[playerIndex] = name;
+      next[teamIndex] = { ...next[teamIndex], playerNames };
+      return next;
+    });
+  };
+
+  const quickFill = () => {
+    setTeams([quickFilledTeam(1), quickFilledTeam(2)]);
+  };
+
+  const startMatch = () => {
+    setGameScore(
+      makeInitialTeams(
+        { name: teams[0].name, playerNames: teams[0].playerNames },
+        { name: teams[1].name, playerNames: teams[1].playerNames }
+      )
+    );
+    router.push("/match");
+  };
+
+  return (
+    <Layout
+      title="Match Setup"
+      description="Enter team and player names before starting your T20 match."
+    >
+      <PageWrapper>
+        <PageHeader>
+          <PageTitle>Match setup</PageTitle>
+          <SecondaryButton type="button" onClick={quickFill}>
+            Quick fill
+          </SecondaryButton>
+        </PageHeader>
+
+        <TeamsGrid>
+          {teams.map((team, teamIndex) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: team slot (0/1) is a stable identity
+            <TeamPanel key={`team-${teamIndex}`}>
+              <TeamNameInput
+                aria-label={`Team ${teamIndex + 1} name`}
+                placeholder={`Team ${teamIndex + 1}`}
+                value={team.name}
+                color={TEAM_COLORS[teamIndex]}
+                onChange={(e) => updateTeamName(teamIndex as 0 | 1, e.target.value)}
+              />
+              <PlayerList>
+                {team.playerNames.map((playerName, playerIndex) => (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: batting-order slot is a stable identity
+                  <PlayerRow key={`team-${teamIndex}-player-${playerIndex}`}>
+                    <PlayerNumber>{playerIndex + 1}.</PlayerNumber>
+                    <PlayerNameInput
+                      aria-label={`Team ${teamIndex + 1} player ${playerIndex + 1} name`}
+                      placeholder={`Player ${playerIndex + 1}`}
+                      value={playerName}
+                      onChange={(e) =>
+                        updatePlayerName(teamIndex as 0 | 1, playerIndex, e.target.value)
+                      }
+                    />
+                  </PlayerRow>
+                ))}
+              </PlayerList>
+            </TeamPanel>
+          ))}
+        </TeamsGrid>
+
+        <ButtonsContainer>
+          <PrimaryButton type="button" onClick={startMatch}>
+            Start Match
+          </PrimaryButton>
+        </ButtonsContainer>
+      </PageWrapper>
+    </Layout>
+  );
+};
+
+export default SetupPage;
+
+const PageWrapper = styled.main`
+  width: 100%;
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+`;
+
+const PageHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 2rem;
+`;
+
+const PageTitle = styled.h1`
+  font-family: "Bodoni Moda", serif;
+  font-style: italic;
+  font-size: 1.75rem;
+  font-weight: 400;
+  margin: 0;
+  color: #1a1a1a;
+`;
+
+const TeamsGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const TeamPanel = styled.div`
+  border: 2px solid #1a1a1a;
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+`;
+
+const TeamNameInput = styled.input<{ color: string }>`
+  width: 100%;
+  font-family: "Bodoni Moda", serif;
+  font-style: italic;
+  font-size: 1.5rem;
+  font-weight: 400;
+  color: #1a1a1a;
+  border: none;
+  border-bottom: 2px solid ${({ color }) => color};
+  padding: 0.25rem 0;
+  margin-bottom: 1rem;
+  background: transparent;
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+const PlayerList = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const PlayerRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0;
+  border-bottom: 1px dashed #ccc;
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+const PlayerNumber = styled.span`
+  font-family: "Bodoni Moda", serif;
+  font-style: italic;
+  font-size: 0.85rem;
+  color: #767676;
+  width: 1.5rem;
+  flex-shrink: 0;
+`;
+
+const PlayerNameInput = styled.input`
+  flex: 1;
+  font-family: "Inter", sans-serif;
+  font-size: 0.9rem;
+  color: #1a1a1a;
+  border: none;
+  border-bottom: 1px solid transparent;
+  padding: 0.25rem 0;
+  background: transparent;
+
+  &:focus {
+    outline: none;
+    border-bottom: 1px solid #1a1a1a;
+  }
+`;
+
+const ButtonsContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 2rem;
+`;


### PR DESCRIPTION
## Summary
- Adds a new `/setup` page where users enter team names and all 22 player names before starting a match.
- Supports spreadsheet-style bulk paste: pasting a comma/newline-separated list into a player field distributes it across that field and subsequent ones, and pasting into the team name field can set the team name plus the whole roster in one go (`Runswick CC, Alice, Bob, ...`) — this is the fast path for casual games rather than a "Quick Fill" button, which turned out to be redundant with the existing blank-field defaults.
- `GameContext`'s `makeInitialTeams` is now parameterized (`TeamSetup = { name?, playerNames? }`) so custom names can be injected while still defaulting to `Team 1`/`Team 2` and `Player 1`..`Player 11` when left blank — this is what keeps existing localStorage-persisted games backward compatible.
- "Start New Match" on the home page now routes to `/setup` instead of building game state inline.

Closes #377

## Test plan
- [x] `yarn jest` — 123 tests passing, including `pages/setup.spec.tsx` covering rendering, blank-field defaults, custom name entry, and bulk paste (player field, mid-roster paste, single-value paste, team-name-field roster paste)
- [x] `yarn tsc --noEmit` — clean
- [x] `yarn lint` — clean
- [ ] Manual check in browser: enter/paste names for both teams, start a match, confirm names appear on Teams/Summary/copy-scorecard

🤖 Generated with [Claude Code](https://claude.com/claude-code)