### PR TITLE
test: add unit tests for defaultPlayers, TeamsPage, and DashboardPage

### DIFF
--- a/__tests__/pages/dashboard.spec.tsx
+++ b/__tests__/pages/dashboard.spec.tsx
@@ -1,0 +1,155 @@
+import { render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { GameScoreContext } from '../../context/GameScoreContext';
+import type { GameScore, GameScoreContextType } from '../../context/GameContext';
+import DashboardPage from '../../pages/dashboard';
+
+type DashboardProps = ComponentProps<typeof DashboardPage>;
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ query: {}, asPath: '/dashboard', push: jest.fn() }),
+}));
+
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(),
+}));
+
+// next-auth/next pulls in jose and openid-client (ESM-only); mock the whole module
+// so Jest does not attempt to parse it.
+jest.mock('next-auth/next', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('../../lib/authOptions', () => ({ authOptions: {} }));
+jest.mock('../../lib/subscription', () => ({ getUserTier: jest.fn() }));
+jest.mock('../../lib/prisma', () => ({ prisma: {} }));
+jest.mock('../../lib/gameSaveTitle', () => ({ generateSaveTitle: jest.fn(() => 'Test Save') }));
+
+jest.mock('../../components/premium/UpgradeCTA', () => ({
+  __esModule: true,
+  default: () => <div data-testid="upgrade-cta" />,
+}));
+
+jest.mock('../../components/saves/SaveCard', () => ({
+  __esModule: true,
+  default: ({ title }: { title: string | null }) => <div data-testid="save-card">{title}</div>,
+}));
+
+const { useSession } = jest.requireMock<{ useSession: jest.Mock }>('next-auth/react');
+
+const emptyContext: GameScoreContextType = {
+  gameScore: [] as unknown as GameScore,
+  setGameScore: jest.fn(),
+  setBattingPlayerScore: jest.fn(),
+  setBowlingPlayerScore: jest.fn(),
+  swapBatsmen: jest.fn(),
+  setCurrentBowler: jest.fn(),
+  undo: jest.fn(),
+  canUndo: false,
+};
+
+const defaultProps: DashboardProps = {
+  tier: 'free',
+  initialSaves: [],
+  initialSeasons: [],
+};
+
+const renderDashboard = (props: DashboardProps = defaultProps) =>
+  render(
+    <GameScoreContext.Provider value={emptyContext}>
+      <DashboardPage {...props} />
+    </GameScoreContext.Provider>
+  );
+
+describe('DashboardPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.clear();
+    localStorage.clear();
+  });
+
+  describe('unauthenticated', () => {
+    beforeEach(() => {
+      useSession.mockReturnValue({ data: null, status: 'unauthenticated' });
+    });
+
+    it('prompts the user to sign in', () => {
+      renderDashboard();
+      expect(screen.getByText(/please/i)).toBeInTheDocument();
+      const signInLinks = screen.getAllByRole('link', { name: /sign in/i });
+      expect(signInLinks.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('renders the Dashboard heading', () => {
+      renderDashboard();
+      expect(screen.getByRole('heading', { name: /dashboard/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('authenticated — free tier', () => {
+    beforeEach(() => {
+      useSession.mockReturnValue({
+        data: { user: { name: 'Alice Smith', email: 'alice@example.com', image: null } },
+        status: 'authenticated',
+      });
+    });
+
+    it('shows the user name and email', () => {
+      renderDashboard();
+      expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+      expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+    });
+
+    it('shows a Free tier badge', () => {
+      renderDashboard();
+      expect(screen.getByText('Free')).toBeInTheDocument();
+    });
+
+    it('shows the empty saves message when there are no saves', () => {
+      renderDashboard();
+      expect(screen.getByText(/no cloud saves yet/i)).toBeInTheDocument();
+    });
+
+    it('renders save cards when saves are present', () => {
+      renderDashboard({
+        ...defaultProps,
+        initialSaves: [
+          { id: 'save-1', title: 'Runswick CC vs Thornton', createdAt: '2026-01-01T00:00:00.000Z', completed: true, seasonId: null },
+        ],
+      });
+      expect(screen.getByTestId('save-card')).toBeInTheDocument();
+      expect(screen.getByText('Runswick CC vs Thornton')).toBeInTheDocument();
+    });
+
+    it('shows the UpgradeCTA and locked seasons section for free users', () => {
+      renderDashboard();
+      expect(screen.getByTestId('upgrade-cta')).toBeInTheDocument();
+    });
+  });
+
+  describe('authenticated — premium tier', () => {
+    beforeEach(() => {
+      useSession.mockReturnValue({
+        data: { user: { name: 'Bob Jones', email: 'bob@example.com', image: null } },
+        status: 'authenticated',
+      });
+    });
+
+    it('shows a Premium tier badge', () => {
+      renderDashboard({ ...defaultProps, tier: 'premium' });
+      expect(screen.getByText('Premium')).toBeInTheDocument();
+    });
+
+    it('shows a link to the Seasons page for premium users', () => {
+      renderDashboard({ ...defaultProps, tier: 'premium' });
+      const link = screen.getByRole('link', { name: /view seasons/i });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute('href', '/seasons');
+    });
+
+    it('does not render the UpgradeCTA for premium users', () => {
+      renderDashboard({ ...defaultProps, tier: 'premium' });
+      expect(screen.queryByTestId('upgrade-cta')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/pages/teams.spec.tsx
+++ b/__tests__/pages/teams.spec.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from '@testing-library/react';
+import { GameScoreContext } from '../../context/GameScoreContext';
+import type { GameScore, GameScoreContextType, TeamPlayer } from '../../context/GameContext';
+import TeamsPage from '../../pages/teams';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ asPath: '/teams' }),
+}));
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+const makePlayer = (overrides: Partial<TeamPlayer> = {}): TeamPlayer => ({
+  index: 0,
+  name: 'Player 1',
+  runs: 0,
+  wicketsTaken: 0,
+  currentStriker: false,
+  currentNonStriker: false,
+  currentBowler: false,
+  allActions: [],
+  onTheCrease: false,
+  status: 'Not out',
+  methodOfWicket: null,
+  oversBowled: 0,
+  runsConceded: 0,
+  ...overrides,
+});
+
+const baseGameScore: GameScore = [
+  {
+    index: 0,
+    name: 'Runswick CC',
+    players: [
+      makePlayer({ index: 0, name: 'Alice', runs: 45, allActions: ['4', '4', '6'], currentStriker: true, onTheCrease: true }),
+      makePlayer({ index: 1, name: 'Bob', runs: 12, allActions: ['1', '1'], currentNonStriker: true, onTheCrease: true }),
+      makePlayer({ index: 2, name: 'Carol', runs: 0, allActions: [] }),
+    ],
+    totalRuns: 57,
+    totalWicketsConceded: 1,
+    totalWicketsTaken: 2,
+    overs: 8.0,
+    currentBattingTeam: true,
+    currentBowlingTeam: false,
+    finishedBatting: false,
+  },
+  {
+    index: 1,
+    name: 'Thornton XI',
+    players: [
+      makePlayer({ index: 0, name: 'Dave', runs: 0, allActions: [], currentBowler: true }),
+      makePlayer({ index: 1, name: 'Eve', runs: 0, allActions: [], wicketsTaken: 1 }),
+    ],
+    totalRuns: 0,
+    totalWicketsConceded: 0,
+    totalWicketsTaken: 1,
+    overs: 0,
+    currentBattingTeam: false,
+    currentBowlingTeam: true,
+    finishedBatting: false,
+  },
+];
+
+const contextValue: GameScoreContextType = {
+  gameScore: baseGameScore,
+  setGameScore: jest.fn(),
+  setBattingPlayerScore: jest.fn(),
+  setBowlingPlayerScore: jest.fn(),
+  swapBatsmen: jest.fn(),
+  setCurrentBowler: jest.fn(),
+  undo: jest.fn(),
+  canUndo: false,
+};
+
+const renderTeams = (overrides?: Partial<GameScoreContextType>) =>
+  render(
+    <GameScoreContext.Provider value={{ ...contextValue, ...overrides }}>
+      <TeamsPage />
+    </GameScoreContext.Provider>
+  );
+
+describe('TeamsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders both team names', () => {
+    renderTeams();
+    expect(screen.getByText('Runswick CC')).toBeInTheDocument();
+    expect(screen.getByText('Thornton XI')).toBeInTheDocument();
+  });
+
+  it('shows the formatted score for each team', () => {
+    renderTeams();
+    expect(screen.getByText('57/1 (8.0)')).toBeInTheDocument();
+    expect(screen.getByText('0/0 (0.0)')).toBeInTheDocument();
+  });
+
+  it('renders player names and their stats', () => {
+    renderTeams();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+    expect(screen.getByText('Dave')).toBeInTheDocument();
+
+    const allRuns = screen.getAllByText('RUNS');
+    expect(allRuns.length).toBeGreaterThan(0);
+  });
+
+  it('shows STRIKE badge on the current striker', () => {
+    renderTeams();
+    expect(screen.getByText('STRIKE')).toBeInTheDocument();
+  });
+
+  it('shows NON badge on the current non-striker', () => {
+    renderTeams();
+    expect(screen.getByText('NON')).toBeInTheDocument();
+  });
+
+  it('shows BOWLING badge on the current bowler', () => {
+    renderTeams();
+    expect(screen.getByText('BOWLING')).toBeInTheDocument();
+  });
+
+  it('renders team initials badges from team names', () => {
+    renderTeams();
+    expect(screen.getByText('RC')).toBeInTheDocument();
+    expect(screen.getByText('TX')).toBeInTheDocument();
+  });
+});

--- a/components/core/players.spec.ts
+++ b/components/core/players.spec.ts
@@ -1,0 +1,63 @@
+import defaultPlayers from './players';
+
+describe('defaultPlayers', () => {
+  it('creates exactly 11 players', () => {
+    expect(defaultPlayers()).toHaveLength(11);
+  });
+
+  it('uses fallback names "Player N" when no names are provided', () => {
+    const players = defaultPlayers();
+    expect(players[0].name).toBe('Player 1');
+    expect(players[5].name).toBe('Player 6');
+    expect(players[10].name).toBe('Player 11');
+  });
+
+  it('uses provided names and falls back to defaults for missing slots', () => {
+    const players = defaultPlayers(['Alice', 'Bob', 'Carol']);
+    expect(players[0].name).toBe('Alice');
+    expect(players[1].name).toBe('Bob');
+    expect(players[2].name).toBe('Carol');
+    expect(players[3].name).toBe('Player 4');
+    expect(players[10].name).toBe('Player 11');
+  });
+
+  it('trims whitespace from provided names', () => {
+    const players = defaultPlayers(['  Alice  ', '  Bob  ']);
+    expect(players[0].name).toBe('Alice');
+    expect(players[1].name).toBe('Bob');
+  });
+
+  it('sets player 0 as currentStriker and player 1 as currentNonStriker', () => {
+    const players = defaultPlayers();
+    expect(players[0].currentStriker).toBe(true);
+    expect(players[0].currentNonStriker).toBe(false);
+    expect(players[1].currentStriker).toBe(false);
+    expect(players[1].currentNonStriker).toBe(true);
+    players.slice(2).forEach((p) => {
+      expect(p.currentStriker).toBe(false);
+      expect(p.currentNonStriker).toBe(false);
+    });
+  });
+
+  it('marks only players 0 and 1 as onTheCrease', () => {
+    const players = defaultPlayers();
+    expect(players[0].onTheCrease).toBe(true);
+    expect(players[1].onTheCrease).toBe(true);
+    players.slice(2).forEach((p) => { expect(p.onTheCrease).toBe(false); });
+  });
+
+  it('initialises every player with zero runs, wickets, overs bowled, and empty actions', () => {
+    const players = defaultPlayers();
+    players.forEach((p, i) => {
+      expect(p.runs).toBe(0);
+      expect(p.wicketsTaken).toBe(0);
+      expect(p.oversBowled).toBe(0);
+      expect(p.runsConceded).toBe(0);
+      expect(p.allActions).toEqual([]);
+      expect(p.bowlingActions).toEqual([]);
+      expect(p.status).toBe('Not out');
+      expect(p.methodOfWicket).toBeNull();
+      expect(p.index).toBe(i);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **`components/core/players.spec.ts`** (7 tests): Covers `defaultPlayers` — verifies the function creates exactly 11 players, uses correct fallback names (`"Player N"`), applies and trims provided names, sets the correct striker/non-striker/on-the-crease flags, and zero-initialises all stats.
- **`__tests__/pages/teams.spec.tsx`** (7 tests): Covers `TeamsPage` — team names and formatted scores (`runs/wickets (overs)`), player names, and the `STRIKE`, `NON`, and `BOWLING` status badges based on player roles.
- **`__tests__/pages/dashboard.spec.tsx`** (10 tests): Covers `DashboardPage` across three states — unauthenticated (sign-in prompt), free tier (user info, Free badge, empty saves, UpgradeCTA), and premium tier (Premium badge, Seasons link, no UpgradeCTA). Mocks `next-auth/next` to prevent Jest parsing ESM-only `jose`/`openid-client` modules.

## Why

These were the three most significant untested areas in the codebase:

- `defaultPlayers` is a core utility called every time a new match is initialised — its name-fallback and player-flag logic was entirely uncovered.
- `TeamsPage` is a full user-facing page with no tests despite rendering player role badges and score formatting.
- `DashboardPage` is the main authenticated landing page with branching UI for free/premium tiers and multiple conditional states.

All 181 tests pass; `yarn lint` (TypeScript + Biome) is clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjEMzxPExQps7QqF66KFzq)_